### PR TITLE
docs(infra): close monorepo skeleton doc gaps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -94,6 +94,12 @@ backend/pubspec.lock
 
 # Coverage
 coverage/
+*.lcov
+
+# Environment variables / secrets
+.env
+.env.*
+!.env.example
 
 # Web related
 lib/generated_plugin_registrant.dart

--- a/README.md
+++ b/README.md
@@ -24,16 +24,39 @@ hotelyn/
 
 **Prerequisites:** Flutter stable channel, Dart ≥ 3.5.0, [Melos](https://melos.codes) ≥ 7.
 
-```bash
-# Activate Melos globally (once)
-dart pub global activate melos
+Follow these steps in order on a fresh clone:
 
-# Install all workspace dependencies from the repo root
-dart pub get
+1. Install Flutter (stable channel) by following the [official install guide](https://docs.flutter.dev/get-started/install) for your OS.
+2. Confirm your toolchain is healthy:
+   ```bash
+   flutter doctor
+   ```
+   Resolve any issues it reports (e.g. missing Android/iOS toolchains) before continuing.
+3. Clone the repository and `cd` into it:
+   ```bash
+   git clone https://github.com/enzoftware/hotelyn.git
+   cd hotelyn
+   ```
+4. Activate Melos globally (once per machine), then make sure the Pub cache `bin` directory is on your `PATH` so the `melos` command is available in new shells:
+   ```bash
+   dart pub global activate melos
+   export PATH="$PATH:$HOME/.pub-cache/bin"
+   ```
+5. Bootstrap the workspace — this resolves and links every app/package/server in one shot:
+   ```bash
+   melos bootstrap
+   ```
+6. Verify the workspace is healthy:
+   ```bash
+   melos run analyze
+   melos run test
+   ```
+7. Re-run `flutter doctor` — it should be clean with no unresolved issues:
+   ```bash
+   flutter doctor
+   ```
 
-# Or bootstrap via Melos (equivalent, also links packages)
-melos bootstrap
-```
+No other manual setup is required. Steps 1–7 are the complete bootstrap sequence for a new machine.
 
 ## Running the app
 


### PR DESCRIPTION
## Summary

- #154 (INFRA-101) asked for a monorepo skeleton, but INFRA-1004 (#209, merged via #221) already shipped an equivalent skeleton under different, more mature naming (`apps/hotelyn_app`, `packages/hotelyn_domain`, `backend/`, etc.) before #154 was actioned. Per discussion, the shipped layout is being kept as-is rather than renamed.
- This PR closes the remaining gaps in #154's acceptance criteria against the structure that actually shipped:
  - `README.md` now has a numbered, start-to-finish bootstrap sequence (`flutter doctor` → clone → activate Melos → `melos bootstrap` → analyze/test → `flutter doctor` clean check), including the `PATH` step needed for `melos` to be runnable on a fresh machine (flagged by CodeRabbit review).
  - `.gitignore` now excludes `.env` / `.env.*` (with a `.env.example` exception) ahead of secrets management work (INFRA-1003).

## Test plan

- [x] `melos run analyze` passes with no new warnings across all packages
- [x] `coderabbit review` run against the diff; the one actionable finding (missing `PATH` step for Melos) fixed
- [x] Manually re-read `README.md` bootstrap sequence end-to-end for a fresh-clone walkthrough

Closes #154

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded the setup guide with a clearer, step-by-step first-time machine bootstrap process.
  * Added validation steps to help confirm the workspace is ready after setup.

* **Chores**
  * Updated ignore rules to exclude coverage report files and local environment/secrets files, while keeping the sample environment file tracked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->