### PR TITLE
feat(infra): configure Resend SMTP for email OTP delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,10 +135,8 @@ Resend's free quota covers the entire MVP phase at zero cost. See issue
 
 5. Add the two variables to your CI secrets / Supabase project secrets (see
    `backend/.env.example`):
-   ```
-   RESEND_SMTP_PASSWORD=re_<your_key>
-   RESEND_FROM_EMAIL=onboarding@resend.dev
-   ```
+5. Add the two variables to your CI secrets / Supabase project secrets (see
+   `backend/.env.example`):
 6. In **Auth → Email**, set the OTP expiry to **600 seconds** (10 min) —
    already configured in `supabase/config.toml` for the local stack.
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,61 @@ Migrations live in `supabase/migrations/`; the first one enables the `postgis` e
 supabase db reset
 ```
 
+### Email testing (local)
+
+Auth emails (OTP codes) are **not** sent to a real inbox during local development.
+They are captured by the built-in inbucket viewer at
+**http://127.0.0.1:54324** — open it in your browser after `supabase start` to
+read any OTP that would have been delivered.
+
+## Email delivery (Resend)
+
+Guest authentication uses email OTP. In staging and production, Supabase Auth
+delivers the 6-digit code via [Resend](https://resend.com) (free tier: 3,000
+emails/month, 100/day).
+
+### Why Resend, not SMS?
+
+SMS providers (Twilio, MessageBird, Vonage) charge per message with no free
+tier. LatAm — the primary Hotelyn market — has among the highest per-SMS rates.
+Resend's free quota covers the entire MVP phase at zero cost. See issue
+[#158](https://github.com/enzoftware/hotelyn/issues/158) for the decision record.
+
+### One-time Resend setup (staging / production)
+
+> Local dev does **not** need this. Emails are captured by the inbucket at
+> `http://127.0.0.1:54324`.
+
+1. Create a free account at <https://resend.com>.
+2. Generate an API key under **Resend → API Keys**. Keep it secret — never
+   commit it.
+3. **Optional (recommended for production):** Verify your sending domain under
+   **Resend → Domains** to avoid spam filters. For staging you can use the
+   shared `onboarding@resend.dev` sender without any domain setup.
+4. In the **Supabase Dashboard** for your hosted project, go to
+   **Auth → SMTP Settings** and fill in:
+
+   | Field | Value |
+   |---|---|
+   | Host | `smtp.resend.com` |
+   | Port | `587` |
+   | Username | `resend` |
+   | Password | *(your Resend API key)* |
+   | Sender name | `Hotelyn` |
+   | Sender email | your verified address, or `onboarding@resend.dev` for staging |
+
+5. Add the two variables to your CI secrets / Supabase project secrets (see
+   `backend/.env.example`):
+   ```
+   RESEND_SMTP_PASSWORD=re_<your_key>
+   RESEND_FROM_EMAIL=onboarding@resend.dev
+   ```
+6. In **Auth → Email**, set the OTP expiry to **600 seconds** (10 min) —
+   already configured in `supabase/config.toml` for the local stack.
+
+> **Never** commit your Resend API key. Store it in CI/CD secrets and in the
+> Supabase project's secret manager only.
+
 ## Running the app
 
 Each app has three entry points — one per environment:

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -21,3 +21,23 @@ SUPABASE_SERVICE_ROLE_KEY=your-local-service-role-key
 
 # Port the Dart Frog server listens on.
 PORT=8080
+
+# ── Resend SMTP (staging / production only) ───────────────────────────────────
+# Not required for local development — the Supabase inbucket at
+# http://127.0.0.1:54324 captures all outgoing auth emails locally.
+#
+# For staging / production:
+#   1. Sign up at https://resend.com (free: 3,000 emails/month, 100/day).
+#   2. Create an API key in Resend → API Keys. Never commit it.
+#   3. For a custom "from" address: verify your domain in Resend → Domains.
+#      For staging without a domain: use the shared onboarding@resend.dev sender.
+#   4. Set these variables in your CI secrets / Supabase project secrets.
+#   5. Optionally uncomment [auth.email.smtp] in supabase/config.toml if you
+#      want to test real delivery from the local CLI stack.
+
+# Resend API key used as the SMTP password. Format: re_<random>.
+RESEND_SMTP_PASSWORD=re_your_api_key_here
+
+# Verified sender address in your Resend account.
+# Use onboarding@resend.dev for staging if you have not verified a domain yet.
+RESEND_FROM_EMAIL=onboarding@resend.dev

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -195,9 +195,10 @@ password_requirements = ""
 # rp_origins = ["http://127.0.0.1:3000"]
 
 [auth.rate_limit]
-# Number of emails that can be sent per hour. Requires auth.email.smtp to be enabled.
-email_sent = 2
-# Number of SMS messages that can be sent per hour. Requires auth.sms to be enabled.
+# Number of emails that can be sent per hour. Resend free tier allows 100/day;
+# 5/hour is a safe cap that still accommodates normal usage.
+email_sent = 5
+# SMS is disabled (phone OTP replaced by email OTP — see INFRA-105).
 sms_sent = 30
 # Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
 anonymous_users = 30
@@ -222,26 +223,45 @@ enable_signup = true
 # If enabled, a user will be required to confirm any email change on both the old, and new email
 # addresses. If disabled, only the new email is required to confirm.
 double_confirm_changes = true
-# If enabled, users need to confirm their email address before signing in.
+# For OTP-based login (signInWithOtp), email confirmations are validated by the
+# OTP code itself — the 6-digit code proves inbox access. Keep false.
 enable_confirmations = false
 # If enabled, users will need to reauthenticate or have logged in recently to change their password.
 secure_password_change = false
-# Controls the minimum amount of time that must pass before sending another signup confirmation or password reset email.
-max_frequency = "1s"
+# Minimum time between successive OTP requests per address. 60 s prevents
+# rapid-fire code requests while staying comfortable for guests who mistype.
+max_frequency = "60s"
 # Number of characters used in the email OTP.
 otp_length = 6
-# Number of seconds before the email OTP expires (defaults to 1 hour).
-otp_expiry = 3600
+# Email OTP validity window: 600 s (10 min) balances security and the latency
+# of transactional email delivery via Resend. Was 3600 s (1 h) — too long.
+otp_expiry = 600
 
-# Use a production-ready SMTP server
+# ─── Resend SMTP (staging / production) ──────────────────────────────────────
+# Local dev does NOT need this — emails are captured by the inbucket viewer at
+# http://127.0.0.1:54324. Uncomment only when running `supabase start` with a
+# real RESEND_SMTP_PASSWORD env var and you want to smoke-test real delivery.
+#
+# For HOSTED Supabase projects (staging / production), configure SMTP via the
+# Supabase Dashboard → Auth → SMTP Settings using the same values below.
+# Do NOT uncomment this block for hosted projects — config.toml only affects
+# the local CLI stack.
+#
+# Setup steps (one-time):
+#   1. Create a free account at https://resend.com (3,000 emails/month, 100/day).
+#   2. Generate an API key under Resend → API Keys. Keep it secret; never commit.
+#   3. Verify a sending domain under Resend → Domains, OR use the shared
+#      onboarding@resend.dev sender for staging (no domain setup required).
+#   4. Set RESEND_SMTP_PASSWORD and RESEND_FROM_EMAIL in backend/.env
+#      (see backend/.env.example for the exact variable names).
 # [auth.email.smtp]
 # enabled = true
-# host = "smtp.sendgrid.net"
+# host = "smtp.resend.com"
 # port = 587
-# user = "apikey"
-# pass = "env(SENDGRID_API_KEY)"
-# admin_email = "admin@email.com"
-# sender_name = "Admin"
+# user = "resend"
+# pass = "env(RESEND_SMTP_PASSWORD)"
+# admin_email = "env(RESEND_FROM_EMAIL)"
+# sender_name = "Hotelyn"
 
 # Uncomment to customize email template
 # [auth.email.template.invite]

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -195,10 +195,13 @@ password_requirements = ""
 # rp_origins = ["http://127.0.0.1:3000"]
 
 [auth.rate_limit]
-# Number of emails that can be sent per hour. Resend free tier allows 100/day;
-# 5/hour is a safe cap that still accommodates normal usage.
+# Project-wide cap on auth emails sent per hour (OTP codes, confirmations, etc.).
+# Resend free tier allows 100 emails/day globally; 5/hour leaves headroom for
+# multiple concurrent users requesting codes without hitting the daily ceiling.
 email_sent = 5
-# SMS is disabled (phone OTP replaced by email OTP — see INFRA-105).
+# Project-wide cap on SMS messages per hour. Kept at the Supabase default;
+# effectively inert because [auth.sms].enable_signup = false (phone OTP replaced
+# by email OTP — see INFRA-105).
 sms_sent = 30
 # Number of anonymous sign-ins that can be made per hour per IP address. Requires enable_anonymous_sign_ins = true.
 anonymous_users = 30


### PR DESCRIPTION
## Summary

- Switches the auth email delivery channel from SMS (no free tier, costly in LatAm) to **email OTP via [Resend](https://resend.com)** (free: 3,000 emails/month, 100/day) — see decision record in #158
- `supabase/config.toml`:
  - `otp_expiry` tightened from 3,600 s (1 h) → **600 s (10 min)** — appropriate for transactional email OTP
  - `max_frequency` raised from 1 s → **60 s** — prevents rapid-fire OTP request spam per address
  - `email_sent` rate-limit raised from 2/h → **5/h** (project-wide; fits Resend 100/day free tier)
  - Replaced the stale SendGrid SMTP comment block with a **Resend SMTP template** (kept commented out — local dev uses the built-in inbucket at `:54324`)
  - `sms_sent` kept at default with an updated comment clarifying it is inert while `[auth.sms].enable_signup = false`
- `backend/.env.example`: added `RESEND_SMTP_PASSWORD` and `RESEND_FROM_EMAIL` with one-time setup instructions
- `README.md`: added "Email testing (local)" inbucket note and a full "Email delivery (Resend)" section with rationale and step-by-step staging/production setup guide

Closes #158

## Test plan

- [ ] `supabase/config.toml` parses without errors (`python3 -c "import tomllib; tomllib.load(open('supabase/config.toml','rb'))"`)
- [ ] `supabase start` succeeds locally with the updated config (no auth errors on start)
- [ ] After `supabase start`, OTP email for a test address appears in the inbucket at `http://127.0.0.1:54324` (confirms local dev flow still works without Resend)
- [ ] `melos run analyze` passes with no new warnings
- [ ] `melos run test` is green
- [ ] Staging: configure SMTP in Supabase Dashboard using the Resend values from README; request OTP and confirm delivery to a real inbox; verify `verifyOtp` succeeds end-to-end
- [ ] Confirm `RESEND_SMTP_PASSWORD` is stored only in project secrets — not in any committed file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Clarified how one-time OTP emails behave in local development versus staging/production, including where local messages can be viewed.
  * Added detailed email delivery (Resend) setup guidance, required environment variables, and OTP expiry/rate behavior notes.

* **New Features**
  * Enabled Resend-based OTP email delivery for staging and production.

* **Bug Fixes**
  * Increased the hourly limit for sent OTP emails.
  * Updated OTP frequency and reduced OTP expiry to improve sign-in reliability.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->