### PR TITLE
feat(db): core schema, PostGIS, RLS policies, and seed

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,30 +65,49 @@ The app never talks to Supabase directly (see [Architecture](CLAUDE.md#architect
 
 **Prerequisites:** [Docker](https://www.docker.com/products/docker-desktop/) running, [Supabase CLI](https://supabase.com/docs/guides/local-development/cli/getting-started) ≥ 2.x.
 
-1. Start the stack (Postgres, Auth, Storage, Realtime, PostgREST, Studio):
+1. Start the stack (Postgres, Auth, Storage, Realtime, PostgREST, Studio). On the
+   first run this also applies every migration in `supabase/migrations/` and loads
+   `supabase/seed.sql`:
    ```bash
    supabase start
    ```
-2. Confirm every service is healthy:
+2. Confirm every service is healthy and note the printed URLs/keys:
    ```bash
    supabase status
    ```
-3. Open Studio at the printed `STUDIO_URL` (defaults to `http://127.0.0.1:54323`) to browse the seeded schema.
-4. Copy the env templates and fill in the values `supabase status` printed:
+3. Apply the schema and (re)load the seed data. Run this whenever migrations or
+   `supabase/seed.sql` change, or whenever you want a clean, known dataset — it
+   drops the local database, re-runs all migrations (the first enables `postgis`),
+   then loads the seed:
+   ```bash
+   supabase db reset
+   ```
+   The seed is **idempotent and deterministic** (fixed IDs/coordinates), so a
+   reset always produces the same six hotels, their rooms, and the two test
+   accounts listed under [Data model](#data-model) — safe to run as often as you
+   like.
+4. Verify the seed loaded (should print `6`). Copy `DB_URL` from `supabase status`:
+   ```bash
+   psql "$DB_URL" -c 'select count(*) from hotels;'
+   ```
+   No local `psql`? Browse the tables in Studio (step 6), or run the query inside
+   the database container:
+   ```bash
+   docker exec -it supabase_db_hotelyn \
+     psql -U postgres -d postgres -c 'select count(*) from public.hotels;'
+   ```
+5. Copy the env templates and fill in the values `supabase status` printed:
    ```bash
    cp backend/.env.example backend/.env
    cp apps/hotelyn_app/.env.example apps/hotelyn_app/.env
    cp apps/hotelyn_dashboard/.env.example apps/hotelyn_dashboard/.env
    ```
-5. When you're done, stop the stack:
+6. Open Studio at the printed `STUDIO_URL` (defaults to `http://127.0.0.1:54323`)
+   to browse the seeded schema and data.
+7. When you're done, stop the stack:
    ```bash
    supabase stop
    ```
-
-Migrations live in `supabase/migrations/`; the first one enables the `postgis` extension. To apply all migrations to a fresh database:
-```bash
-supabase db reset
-```
 
 ### Data model
 
@@ -104,9 +123,10 @@ types and Row Level Security:
 
 RLS is enabled on every table: guests browse available rooms and manage only
 their own reservations; hotel staff read/write only their own hotel's rooms and
-reservations. `supabase db reset` also loads `supabase/seed.sql` — deterministic
-hotels across six LatAm + North America launch cities and two test accounts
-(local password `password123`):
+reservations. The seed (`supabase/seed.sql`, loaded by `supabase db reset`) is
+deterministic: six hotels across LatAm + North America launch cities, a mix of
+available/unavailable rooms, and two test accounts (local password
+`password123`):
 
 | Account              | Role          |
 | -------------------- | ------------- |

--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ hotels across six LatAm + North America launch cities and two test accounts
 Metre-accurate proximity search casts `location` to `geography` (a distance in
 metres), which is served by the dedicated functional GiST index rather than the
 degree-based one:
+
 ```sql
 -- hotels within 5 km of a point (lon, lat)
 select name from hotels
@@ -125,6 +126,7 @@ where st_dwithin(location::geography,
 
 The RLS policies are covered by an automated pgTAP test that proves a Hotel A
 staff session cannot read or write Hotel B's data:
+
 ```bash
 supabase test db
 ```

--- a/README.md
+++ b/README.md
@@ -90,6 +90,45 @@ Migrations live in `supabase/migrations/`; the first one enables the `postgis` e
 supabase db reset
 ```
 
+### Data model
+
+The schema (see `supabase/migrations/`) is four normalized tables plus enum
+types and Row Level Security:
+
+| Table          | Notes                                                                              |
+| -------------- | ---------------------------------------------------------------------------------- |
+| `profiles`     | 1:1 with `auth.users`; holds `role` (`guest`/`hotel_staff`/`admin`) + `hotel_id`.  |
+| `hotels`       | Includes a PostGIS `location geometry(Point, 4326)` with a GiST index.             |
+| `rooms`        | FK → `hotels`; `is_available` flags bookable rooms.                                 |
+| `reservations` | FK → `hotels`/`rooms`/`profiles`; `status` enum; index on `(hotel_id, status, created_at)`. |
+
+RLS is enabled on every table: guests browse available rooms and manage only
+their own reservations; hotel staff read/write only their own hotel's rooms and
+reservations. `supabase db reset` also loads `supabase/seed.sql` — deterministic
+hotels across six LatAm + North America launch cities and two test accounts
+(local password `password123`):
+
+| Account              | Role          |
+| -------------------- | ------------- |
+| `guest@hotelyn.test` | `guest`       |
+| `staff@hotelyn.test` | `hotel_staff` (owns the Lima hotel) |
+
+Metre-accurate proximity search casts `location` to `geography` (a distance in
+metres), which is served by the dedicated functional GiST index rather than the
+degree-based one:
+```sql
+-- hotels within 5 km of a point (lon, lat)
+select name from hotels
+where st_dwithin(location::geography,
+                 st_setsrid(st_makepoint(-77.03, -12.11), 4326)::geography, 5000);
+```
+
+The RLS policies are covered by an automated pgTAP test that proves a Hotel A
+staff session cannot read or write Hotel B's data:
+```bash
+supabase test db
+```
+
 ### Email testing (local)
 
 Auth emails (OTP codes) are **not** sent to a real inbox during local development.

--- a/supabase/migrations/20260707130000_core_schema.sql
+++ b/supabase/migrations/20260707130000_core_schema.sql
@@ -1,0 +1,169 @@
+-- BE-201 · Core schema migration
+-- BE-202 · PostGIS geometry column for hotel location
+--
+-- Normalized tables for hotels, rooms, reservations, and user profiles. This is
+-- the single data foundation every later feature builds on, so constraints are
+-- expressed at the DB layer (enums, FKs, NOT NULL, checks) rather than left to
+-- the app to enforce.
+--
+-- Identity lives in Supabase's `auth.users`. App-specific attributes (role,
+-- hotel ownership) live in `profiles`, linked 1:1 to `auth.users` — never in a
+-- parallel custom users table.
+
+-- ---------------------------------------------------------------------------
+-- Enum types
+-- ---------------------------------------------------------------------------
+
+-- Who a profile is and what they may do. Guests book; hotel_staff manage a
+-- single hotel's rooms/reservations; admin oversees everything.
+create type public.user_role as enum ('guest', 'hotel_staff', 'admin');
+
+-- Lifecycle of a reservation. Constrained at the DB layer so a buggy or hostile
+-- client can never persist an out-of-set status.
+--   held      – temporarily reserved while the guest completes checkout
+--   confirmed – payment accepted, booking guaranteed
+--   cancelled – withdrawn by the guest
+--   rejected  – declined by the hotel
+--   expired   – hold lapsed before confirmation
+create type public.reservation_status as enum (
+  'held',
+  'confirmed',
+  'cancelled',
+  'rejected',
+  'expired'
+);
+
+-- ---------------------------------------------------------------------------
+-- Shared updated_at trigger
+-- ---------------------------------------------------------------------------
+
+-- Keeps `updated_at` honest without trusting the client to send it.
+create or replace function public.set_updated_at()
+returns trigger
+language plpgsql
+as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- hotels
+-- ---------------------------------------------------------------------------
+
+create table public.hotels (
+  id          uuid primary key default gen_random_uuid(),
+  name        text not null,
+  description text,
+  address     text,
+  city        text not null,
+  country     text not null,
+  -- BE-202: real PostGIS point (SRID 4326 / WGS 84) instead of two hand-rolled
+  -- float columns. Stored as geometry; metric ("within N metres") proximity
+  -- search casts to geography per query (see the geography GiST index below).
+  location    extensions.geometry(Point, 4326),
+  created_at  timestamptz not null default now(),
+  updated_at  timestamptz not null default now()
+);
+
+comment on column public.hotels.location is
+  'WGS 84 point (lon, lat). Query with ST_DWithin against a GiST index; '
+  'cast to geography for distances in metres.';
+
+-- GiST index on the raw geometry: nearest-neighbour ordering, bounding-box and
+-- degree-unit ST_DWithin.
+create index hotels_location_gix on public.hotels using gist (location);
+
+-- Functional GiST index on the geography cast so metre-accurate proximity
+-- queries (ST_DWithin(location::geography, point::geography, metres)) are also
+-- index-accelerated rather than degree-based and latitude-dependent.
+create index hotels_location_geog_gix
+  on public.hotels using gist ((location::extensions.geography));
+
+create trigger hotels_set_updated_at
+  before update on public.hotels
+  for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- profiles (extends auth.users)
+-- ---------------------------------------------------------------------------
+
+create table public.profiles (
+  -- 1:1 with the Supabase auth user; deleting the auth user removes the profile.
+  id         uuid primary key references auth.users (id) on delete cascade,
+  full_name  text,
+  role       public.user_role not null default 'guest',
+  -- Nullable hotel-ownership link: set for hotel_staff, null for guests/admin.
+  -- ON DELETE SET NULL so removing a hotel does not orphan the FK.
+  hotel_id   uuid references public.hotels (id) on delete set null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create index profiles_hotel_id_idx on public.profiles (hotel_id);
+
+create trigger profiles_set_updated_at
+  before update on public.profiles
+  for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- rooms
+-- ---------------------------------------------------------------------------
+
+create table public.rooms (
+  id              uuid primary key default gen_random_uuid(),
+  -- A room cannot exist without its hotel; cascading delete prevents orphans.
+  hotel_id        uuid not null references public.hotels (id) on delete cascade,
+  name            text not null,
+  room_type       text not null,
+  capacity        integer not null default 1 check (capacity > 0),
+  price_per_night numeric(10, 2) not null check (price_per_night >= 0),
+  is_available    boolean not null default true,
+  created_at      timestamptz not null default now(),
+  updated_at      timestamptz not null default now(),
+  -- Target for reservations' composite FK, so a reservation's room_id and
+  -- hotel_id can never disagree (tenant-scoping integrity).
+  constraint rooms_id_hotel_id_key unique (id, hotel_id)
+);
+
+create index rooms_hotel_id_idx on public.rooms (hotel_id);
+
+create trigger rooms_set_updated_at
+  before update on public.rooms
+  for each row execute function public.set_updated_at();
+
+-- ---------------------------------------------------------------------------
+-- reservations
+-- ---------------------------------------------------------------------------
+
+create table public.reservations (
+  id         uuid primary key default gen_random_uuid(),
+  hotel_id   uuid not null references public.hotels (id) on delete cascade,
+  room_id    uuid not null,
+  -- The booking guest, tied to their profile (and therefore to auth.users).
+  guest_id   uuid not null references public.profiles (id) on delete cascade,
+  status     public.reservation_status not null default 'held',
+  check_in   date not null,
+  check_out  date not null,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  constraint reservations_dates_ordered check (check_out > check_in),
+  -- Composite FK guarantees the room belongs to this hotel; a reservation can
+  -- never reference a room from a different hotel.
+  constraint reservations_room_hotel_fk
+    foreign key (room_id, hotel_id)
+    references public.rooms (id, hotel_id) on delete cascade
+);
+
+-- Supports the BE-304 recommended-ranking query, which filters by hotel and
+-- status and orders by recency, without a full table scan.
+create index reservations_hotel_status_created_idx
+  on public.reservations (hotel_id, status, created_at);
+
+-- Guest-facing "my reservations" lookups.
+create index reservations_guest_id_idx on public.reservations (guest_id);
+
+create trigger reservations_set_updated_at
+  before update on public.reservations
+  for each row execute function public.set_updated_at();

--- a/supabase/migrations/20260707130100_rls_policies.sql
+++ b/supabase/migrations/20260707130100_rls_policies.sql
@@ -1,0 +1,245 @@
+-- BE-203 · Row Level Security policies
+--
+-- With Supabase the client talks to Postgres fairly directly, so RLS *is* the
+-- authorization boundary — an app-layer check is not sufficient. Every table
+-- below has RLS enabled (no table left open by default) and policies that are
+-- deliberately scoped per role and per tenant (hotel). Intent is commented so a
+-- future reader understands *why*, not just *what*.
+--
+-- A wrong policy fails silently: over-permissive leaks data, over-strict breaks
+-- a feature. The accompanying pgTAP test (supabase/tests/rls_test.sql) asserts
+-- the cross-tenant boundary rather than relying on a manual check.
+
+-- ---------------------------------------------------------------------------
+-- Helper functions
+-- ---------------------------------------------------------------------------
+-- Policies need the caller's role and hotel, both stored in `profiles`. Reading
+-- `profiles` directly from inside another table's policy would re-trigger
+-- profiles' own RLS (and can recurse). These SECURITY DEFINER helpers read the
+-- caller's own row with RLS bypassed, which is safe because they only ever
+-- return data about `auth.uid()` itself. (Named *_profile_* to avoid shadowing
+-- Postgres' built-in `current_role`.)
+
+create or replace function public.current_profile_role()
+returns public.user_role
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select role from public.profiles where id = auth.uid();
+$$;
+
+create or replace function public.current_profile_hotel_id()
+returns uuid
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select hotel_id from public.profiles where id = auth.uid();
+$$;
+
+-- CREATE FUNCTION grants EXECUTE to PUBLIC by default. These definer functions
+-- bypass RLS, so restrict them to authenticated callers to trim attack surface.
+revoke execute on function public.current_profile_role()     from public;
+revoke execute on function public.current_profile_hotel_id() from public;
+grant  execute on function public.current_profile_role()     to authenticated;
+grant  execute on function public.current_profile_hotel_id() to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- Enable RLS everywhere
+-- ---------------------------------------------------------------------------
+
+alter table public.hotels       enable row level security;
+alter table public.rooms        enable row level security;
+alter table public.reservations enable row level security;
+alter table public.profiles     enable row level security;
+
+-- ---------------------------------------------------------------------------
+-- Table grants
+-- ---------------------------------------------------------------------------
+-- RLS only filters rows a role is otherwise allowed to touch; without a GRANT the
+-- role cannot reach the table at all. This project does not auto-expose new
+-- tables to the API roles, so grant the DML that the policies below gate. Rows
+-- are still restricted per-role/per-tenant by those policies.
+--
+-- `profiles` is granted at COLUMN level on purpose: `role` and `hotel_id` drive
+-- every authorization decision, so a client that could write them could
+-- self-escalate to admin/staff. RLS WITH CHECK cannot compare against the
+-- pre-update value, so those columns are simply not writable by `authenticated`
+-- — they are provisioned out-of-band (service_role / seed / admin tooling).
+
+grant select, update                 on public.hotels       to authenticated;
+grant select, insert, update, delete on public.rooms        to authenticated;
+grant select, insert, update         on public.reservations to authenticated;
+grant select                         on public.profiles     to authenticated;
+grant insert (id, full_name)         on public.profiles     to authenticated;
+grant update (full_name)             on public.profiles     to authenticated;
+
+-- ---------------------------------------------------------------------------
+-- profiles
+-- ---------------------------------------------------------------------------
+
+-- A user may read and maintain only their own profile row. Admins may read all
+-- (e.g. support tooling). role/hotel_id are not writable by clients (see the
+-- column grants above), so no client can change another user's — or their own —
+-- role or hotel link.
+create policy profiles_select_own
+  on public.profiles for select
+  to authenticated
+  using (id = auth.uid() or (select public.current_profile_role()) = 'admin');
+
+create policy profiles_insert_own
+  on public.profiles for insert
+  to authenticated
+  with check (id = auth.uid());
+
+create policy profiles_update_own
+  on public.profiles for update
+  to authenticated
+  using (id = auth.uid())
+  with check (id = auth.uid());
+
+-- ---------------------------------------------------------------------------
+-- hotels
+-- ---------------------------------------------------------------------------
+
+-- Hotels are a public catalogue: any authenticated user may browse them.
+create policy hotels_select_all
+  on public.hotels for select
+  to authenticated
+  using (true);
+
+-- Only the hotel's own staff (or an admin) may modify it. New hotels are
+-- provisioned out-of-band (service_role / admin), so there is no staff INSERT
+-- policy here. Helper calls are wrapped in a scalar subquery so the planner
+-- evaluates them once per statement (initplan) instead of once per row.
+create policy hotels_update_own
+  on public.hotels for update
+  to authenticated
+  using (
+    (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and id = (select public.current_profile_hotel_id())
+    )
+  )
+  with check (
+    (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and id = (select public.current_profile_hotel_id())
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- rooms
+-- ---------------------------------------------------------------------------
+
+-- Guests browse broadly: any available room is visible. A hotel's own staff (and
+-- admins) additionally see their unavailable rooms for management.
+create policy rooms_select_visible
+  on public.rooms for select
+  to authenticated
+  using (
+    is_available
+    or (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  );
+
+-- Staff may create/modify/remove rooms only for their own hotel; admins for any.
+-- The USING clause keeps a staffer from touching Hotel B's rooms; the WITH CHECK
+-- clause keeps them from reassigning a row into another hotel.
+create policy rooms_insert_own_hotel
+  on public.rooms for insert
+  to authenticated
+  with check (
+    (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  );
+
+create policy rooms_update_own_hotel
+  on public.rooms for update
+  to authenticated
+  using (
+    (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  )
+  with check (
+    (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  );
+
+create policy rooms_delete_own_hotel
+  on public.rooms for delete
+  to authenticated
+  using (
+    (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  );
+
+-- ---------------------------------------------------------------------------
+-- reservations
+-- ---------------------------------------------------------------------------
+
+-- A guest sees only their own reservations. A hotel's staff see every
+-- reservation for their hotel; admins see all.
+create policy reservations_select_scoped
+  on public.reservations for select
+  to authenticated
+  using (
+    guest_id = auth.uid()
+    or (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  );
+
+-- A guest may only create a reservation in their own name, and only in the
+-- initial `held` state — confirming/rejecting is the hotel's job, so a guest
+-- cannot self-confirm. WITH CHECK also stops attributing a booking to someone
+-- else. (The composite room/hotel FK keeps room_id and hotel_id consistent.)
+create policy reservations_insert_own
+  on public.reservations for insert
+  to authenticated
+  with check (guest_id = auth.uid() and status = 'held');
+
+-- A guest may update only their own reservation and only into guest-permitted
+-- states (e.g. cancel) — never self-confirm. Staff may drive their hotel's
+-- reservations through any status (confirm/reject); admins anything.
+create policy reservations_update_scoped
+  on public.reservations for update
+  to authenticated
+  using (
+    guest_id = auth.uid()
+    or (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  )
+  with check (
+    (guest_id = auth.uid() and status in ('held', 'cancelled'))
+    or (select public.current_profile_role()) = 'admin'
+    or (
+      (select public.current_profile_role()) = 'hotel_staff'
+      and hotel_id = (select public.current_profile_hotel_id())
+    )
+  );

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,4 +1,194 @@
--- Seed data for local development. Populated incrementally as domain tables
--- land (see BE-201 and friends); intentionally empty for now so that
--- `supabase db reset` succeeds on a fresh clone with only the PostGIS
--- extension in place.
+-- BE-204 · Seed data script
+--
+-- Idempotent, deterministic seed so local dev and integration tests always start
+-- from realistic, known data. Every id and coordinate is fixed so tests can
+-- assert against them, and every statement is re-runnable (ON CONFLICT), so
+-- `supabase db reset` — and a manual re-run — both succeed with no follow-up.
+--
+-- Contents:
+--   * 6 hotels across real LatAm + North America launch cities (BE-202 coords)
+--   * rooms with a deliberate mix of available / unavailable
+--   * one test guest        (guest@hotelyn.test)
+--   * one test hotel-staff  (staff@hotelyn.test), owning the Lima hotel
+--
+-- Test account password (local only): "password123".
+
+-- PostGIS + pgcrypto (crypt/gen_salt) live in the extensions schema.
+set search_path = public, extensions;
+
+-- ---------------------------------------------------------------------------
+-- Auth users (Supabase identity)
+-- ---------------------------------------------------------------------------
+-- Inserted directly for local dev; on hosted environments real users sign up via
+-- email OTP. Fixed UUIDs let profiles/reservations reference them deterministically.
+
+-- The token/change columns are set to '' (not left NULL): GoTrue's Go scanner
+-- errors with "converting NULL to string is unsupported" when a directly-inserted
+-- row is used to sign in, so empty strings keep these accounts loginable locally.
+insert into auth.users (
+  instance_id, id, aud, role, email, encrypted_password,
+  email_confirmed_at, created_at, updated_at,
+  raw_app_meta_data, raw_user_meta_data,
+  confirmation_token, recovery_token, email_change, email_change_token_new
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '00000000-0000-0000-0000-000000000001',
+    'authenticated', 'authenticated', 'guest@hotelyn.test',
+    crypt('password123', gen_salt('bf')),
+    now(), now(), now(),
+    '{"provider":"email","providers":["email"]}',
+    '{"full_name":"Test Guest"}',
+    '', '', '', ''
+  ),
+  (
+    '00000000-0000-0000-0000-000000000000',
+    '00000000-0000-0000-0000-000000000002',
+    'authenticated', 'authenticated', 'staff@hotelyn.test',
+    crypt('password123', gen_salt('bf')),
+    now(), now(), now(),
+    '{"provider":"email","providers":["email"]}',
+    '{"full_name":"Test Staff"}',
+    '', '', '', ''
+  )
+on conflict (id) do nothing;
+
+-- Email/password identities so the seeded accounts can actually sign in locally.
+insert into auth.identities (
+  id, user_id, provider_id, identity_data, provider,
+  last_sign_in_at, created_at, updated_at
+)
+values
+  (
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000001',
+    '00000000-0000-0000-0000-000000000001',
+    '{"sub":"00000000-0000-0000-0000-000000000001","email":"guest@hotelyn.test"}',
+    'email', now(), now(), now()
+  ),
+  (
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000002',
+    '{"sub":"00000000-0000-0000-0000-000000000002","email":"staff@hotelyn.test"}',
+    'email', now(), now(), now()
+  )
+on conflict (provider_id, provider) do nothing;
+
+-- ---------------------------------------------------------------------------
+-- Hotels (real launch-city coordinates, lon/lat WGS 84)
+-- ---------------------------------------------------------------------------
+
+insert into public.hotels (id, name, description, address, city, country, location)
+values
+  (
+    '10000000-0000-0000-0000-000000000001',
+    'Miraflores Bay Hotel', 'Oceanfront rooms above the Costa Verde.',
+    'Malecon de la Reserva 615', 'Lima', 'Peru',
+    st_setsrid(st_makepoint(-77.0428, -12.1219), 4326)
+  ),
+  (
+    '10000000-0000-0000-0000-000000000002',
+    'Reforma Grand', 'Business hotel on Paseo de la Reforma.',
+    'Paseo de la Reforma 500', 'Mexico City', 'Mexico',
+    st_setsrid(st_makepoint(-99.1682, 19.4270), 4326)
+  ),
+  (
+    '10000000-0000-0000-0000-000000000003',
+    'Zona Rosa Suites', 'Boutique stay in the heart of Bogota.',
+    'Carrera 13 85-32', 'Bogota', 'Colombia',
+    st_setsrid(st_makepoint(-74.0546, 4.6663), 4326)
+  ),
+  (
+    '10000000-0000-0000-0000-000000000004',
+    'Recoleta Palace', 'Classic elegance near the Recoleta cemetery.',
+    'Av. Alvear 1900', 'Buenos Aires', 'Argentina',
+    st_setsrid(st_makepoint(-58.3920, -34.5875), 4326)
+  ),
+  (
+    '10000000-0000-0000-0000-000000000005',
+    'Midtown Central', 'Steps from Bryant Park and Times Square.',
+    '500 5th Ave', 'New York', 'United States',
+    st_setsrid(st_makepoint(-73.9840, 40.7536), 4326)
+  ),
+  (
+    '10000000-0000-0000-0000-000000000006',
+    'Brickell Waterside', 'Modern tower overlooking Biscayne Bay.',
+    '1300 Brickell Bay Dr', 'Miami', 'United States',
+    st_setsrid(st_makepoint(-80.1918, 25.7617), 4326)
+  )
+on conflict (id) do update set
+  name        = excluded.name,
+  description = excluded.description,
+  address     = excluded.address,
+  city        = excluded.city,
+  country     = excluded.country,
+  location    = excluded.location;
+
+-- ---------------------------------------------------------------------------
+-- Profiles (extends auth.users)
+-- ---------------------------------------------------------------------------
+
+insert into public.profiles (id, full_name, role, hotel_id)
+values
+  ('00000000-0000-0000-0000-000000000001', 'Test Guest', 'guest', null),
+  (
+    '00000000-0000-0000-0000-000000000002', 'Test Staff', 'hotel_staff',
+    '10000000-0000-0000-0000-000000000001' -- owns the Lima hotel
+  )
+on conflict (id) do update set
+  full_name = excluded.full_name,
+  role      = excluded.role,
+  hotel_id  = excluded.hotel_id;
+
+-- ---------------------------------------------------------------------------
+-- Rooms (deliberate mix of available / unavailable)
+-- ---------------------------------------------------------------------------
+
+insert into public.rooms (id, hotel_id, name, room_type, capacity, price_per_night, is_available)
+values
+  -- Lima (owned by test staff): one available, one occupied.
+  ('20000000-0000-0000-0000-000000000001', '10000000-0000-0000-0000-000000000001', 'Ocean View 101', 'double', 2, 180.00, true),
+  ('20000000-0000-0000-0000-000000000002', '10000000-0000-0000-0000-000000000001', 'City View 102',  'single', 1,  90.00, false),
+  -- Mexico City
+  ('20000000-0000-0000-0000-000000000003', '10000000-0000-0000-0000-000000000002', 'Executive Suite', 'suite',  4, 320.00, true),
+  ('20000000-0000-0000-0000-000000000004', '10000000-0000-0000-0000-000000000002', 'Standard 210',    'double', 2, 140.00, false),
+  -- Bogota
+  ('20000000-0000-0000-0000-000000000005', '10000000-0000-0000-0000-000000000003', 'Boutique King',   'double', 2, 160.00, true),
+  -- Buenos Aires
+  ('20000000-0000-0000-0000-000000000006', '10000000-0000-0000-0000-000000000004', 'Palace Double',   'double', 2, 210.00, true),
+  ('20000000-0000-0000-0000-000000000007', '10000000-0000-0000-0000-000000000004', 'Palace Single',   'single', 1, 120.00, false),
+  -- New York
+  ('20000000-0000-0000-0000-000000000008', '10000000-0000-0000-0000-000000000005', 'Midtown Queen',   'double', 2, 290.00, true),
+  -- Miami
+  ('20000000-0000-0000-0000-000000000009', '10000000-0000-0000-0000-000000000006', 'Bay View Suite',  'suite',  3, 350.00, true),
+  ('20000000-0000-0000-0000-00000000000a', '10000000-0000-0000-0000-000000000006', 'City Twin',       'twin',   2, 175.00, false)
+on conflict (id) do update set
+  hotel_id        = excluded.hotel_id,
+  name            = excluded.name,
+  room_type       = excluded.room_type,
+  capacity        = excluded.capacity,
+  price_per_night = excluded.price_per_night,
+  is_available    = excluded.is_available;
+
+-- ---------------------------------------------------------------------------
+-- Reservations (one confirmed booking for the test guest at the Lima hotel)
+-- ---------------------------------------------------------------------------
+
+insert into public.reservations (id, hotel_id, room_id, guest_id, status, check_in, check_out)
+values
+  (
+    '30000000-0000-0000-0000-000000000001',
+    '10000000-0000-0000-0000-000000000001',
+    '20000000-0000-0000-0000-000000000002',
+    '00000000-0000-0000-0000-000000000001',
+    'confirmed', date '2026-08-01', date '2026-08-05'
+  )
+on conflict (id) do update set
+  hotel_id  = excluded.hotel_id,
+  room_id   = excluded.room_id,
+  guest_id  = excluded.guest_id,
+  status    = excluded.status,
+  check_in  = excluded.check_in,
+  check_out = excluded.check_out;

--- a/supabase/tests/rls_test.sql
+++ b/supabase/tests/rls_test.sql
@@ -1,0 +1,191 @@
+-- BE-203 · Automated proof of the Row Level Security boundary.
+--
+-- Run with: `supabase test db` (executes every *_test.sql under supabase/tests
+-- inside a rolled-back transaction against the local stack).
+--
+-- The core assertion the ticket demands: a session authenticated as Hotel A
+-- staff must see ZERO rows of, and be unable to write, Hotel B's rooms and
+-- reservations. We also spot-check the guest read/write boundary.
+--
+-- throws_ok asserts on SQLSTATE 42501 (insufficient_privilege) with a NULL
+-- message so the tests do not break on a differently-localized error string.
+
+begin;
+
+select plan(13);
+
+-- ---------------------------------------------------------------------------
+-- Fixtures (Hotel A = staff's own hotel, Hotel B = a foreign hotel)
+-- ---------------------------------------------------------------------------
+-- Seeded ids (see supabase/seed.sql):
+--   Hotel A  = Lima   10000000-...0001  (owned by staff 000...0002)
+--   Hotel B  = Mexico 10000000-...0002
+--   Room B   = 200...0003 (Mexico), Room A(available) = 200...0001 (Lima)
+
+-- Inserted as the table owner (bypasses RLS) so the boundary assertions below
+-- have foreign rows to (fail to) reach.
+
+-- A reservation on Hotel B, so "select foreign reservations" has a target.
+insert into public.reservations (id, hotel_id, room_id, guest_id, status, check_in, check_out)
+values (
+  '30000000-0000-0000-0000-0000000000b1',
+  '10000000-0000-0000-0000-000000000002',           -- Hotel B
+  '20000000-0000-0000-0000-000000000003',           -- Room B
+  '00000000-0000-0000-0000-000000000001',           -- test guest
+  'confirmed', date '2026-09-01', date '2026-09-03'
+);
+
+-- A reservation on Hotel A owned by the STAFF profile, so we can prove a guest
+-- cannot read a reservation that is not theirs even at a hotel they can browse.
+insert into public.reservations (id, hotel_id, room_id, guest_id, status, check_in, check_out)
+values (
+  '30000000-0000-0000-0000-0000000000b2',
+  '10000000-0000-0000-0000-000000000001',           -- Hotel A
+  '20000000-0000-0000-0000-000000000001',           -- Room A (available)
+  '00000000-0000-0000-0000-000000000002',           -- staff profile, not the guest
+  'held', date '2026-09-10', date '2026-09-12'
+);
+
+-- ---------------------------------------------------------------------------
+-- Authenticate as Hotel A staff
+-- ---------------------------------------------------------------------------
+set local role authenticated;
+set local request.jwt.claims to
+  '{"sub":"00000000-0000-0000-0000-000000000002","role":"authenticated"}';
+
+-- Sanity: staff CAN see their own hotel's rooms (both available + unavailable).
+select is(
+  (select count(*)::int from public.rooms
+     where hotel_id = '10000000-0000-0000-0000-000000000001'),
+  2,
+  'Hotel A staff sees all of their own hotel rooms'
+);
+
+-- Boundary #1: staff sees ZERO of Hotel B's *unavailable* rooms.
+select is(
+  (select count(*)::int from public.rooms
+     where hotel_id = '10000000-0000-0000-0000-000000000002'
+       and is_available = false),
+  0,
+  'Hotel A staff cannot see Hotel B unavailable rooms'
+);
+
+-- Boundary #2: staff sees ZERO of Hotel B's reservations.
+select is(
+  (select count(*)::int from public.reservations
+     where hotel_id = '10000000-0000-0000-0000-000000000002'),
+  0,
+  'Hotel A staff cannot read Hotel B reservations'
+);
+
+-- Staff CAN see their own hotel's reservations (seeded booking + fixture b2).
+select is(
+  (select count(*)::int from public.reservations
+     where hotel_id = '10000000-0000-0000-0000-000000000001'),
+  2,
+  'Hotel A staff can read their own hotel reservations'
+);
+
+-- Boundary #3: staff UPDATE of a Hotel B room affects ZERO rows.
+with upd as (
+  update public.rooms set price_per_night = 1.00
+   where id = '20000000-0000-0000-0000-000000000003'
+  returning 1
+)
+select is(
+  (select count(*)::int from upd),
+  0,
+  'Hotel A staff UPDATE of a Hotel B room is rejected (0 rows)'
+);
+
+-- Boundary #4: staff DELETE of a Hotel B room affects ZERO rows.
+with del as (
+  delete from public.rooms
+   where id = '20000000-0000-0000-0000-000000000003'
+  returning 1
+)
+select is(
+  (select count(*)::int from del),
+  0,
+  'Hotel A staff DELETE of a Hotel B room is rejected (0 rows)'
+);
+
+-- Boundary #5: staff INSERT of a room into Hotel B is rejected.
+select throws_ok(
+  $$insert into public.rooms (hotel_id, name, room_type, price_per_night)
+    values ('10000000-0000-0000-0000-000000000002', 'Rogue', 'double', 5.00)$$,
+  '42501',
+  NULL,
+  'Hotel A staff INSERT into Hotel B is rejected'
+);
+
+-- Staff CAN update their own hotel's room.
+with upd as (
+  update public.rooms set price_per_night = price_per_night
+   where id = '20000000-0000-0000-0000-000000000001'
+  returning 1
+)
+select is(
+  (select count(*)::int from upd),
+  1,
+  'Hotel A staff CAN update their own hotel room'
+);
+
+-- ---------------------------------------------------------------------------
+-- Authenticate as the guest
+-- ---------------------------------------------------------------------------
+set local request.jwt.claims to
+  '{"sub":"00000000-0000-0000-0000-000000000001","role":"authenticated"}';
+
+-- A guest can browse available rooms broadly (all seeded available rooms).
+select cmp_ok(
+  (select count(*)::int from public.rooms where is_available = true),
+  '>=', 6,
+  'Guest can browse available rooms broadly'
+);
+
+-- Boundary #6: a guest cannot read a reservation that is not theirs, even at a
+-- hotel they can browse (fixture b2 is owned by the staff profile).
+select is(
+  (select count(*)::int from public.reservations
+     where guest_id = '00000000-0000-0000-0000-000000000002'),
+  0,
+  'Guest cannot read another user''s reservation'
+);
+
+-- Boundary #7: a guest cannot escalate privilege by writing their own role.
+-- `role`/`hotel_id` are not granted to `authenticated`, so the write is a
+-- column-privilege error, not merely an RLS row filter.
+select throws_ok(
+  $$update public.profiles set role = 'admin'
+     where id = '00000000-0000-0000-0000-000000000001'$$,
+  '42501',
+  NULL,
+  'Guest cannot escalate their own role to admin'
+);
+
+-- A guest cannot insert a reservation attributed to someone else.
+select throws_ok(
+  $$insert into public.reservations (hotel_id, room_id, guest_id, status, check_in, check_out)
+    values ('10000000-0000-0000-0000-000000000001',
+            '20000000-0000-0000-0000-000000000001',
+            '00000000-0000-0000-0000-000000000002', -- not the guest
+            'held', date '2026-10-01', date '2026-10-02')$$,
+  '42501',
+  NULL,
+  'Guest cannot insert a reservation in another user''s name'
+);
+
+-- A guest CAN insert a reservation in their own name (initial held state).
+select lives_ok(
+  $$insert into public.reservations (hotel_id, room_id, guest_id, status, check_in, check_out)
+    values ('10000000-0000-0000-0000-000000000001',
+            '20000000-0000-0000-0000-000000000001',
+            '00000000-0000-0000-0000-000000000001', -- the guest themself
+            'held', date '2026-10-01', date '2026-10-02')$$,
+  'Guest CAN insert a reservation in their own name'
+);
+
+select * from finish();
+
+rollback;

--- a/supabase/tests/rls_test.sql
+++ b/supabase/tests/rls_test.sql
@@ -12,7 +12,7 @@
 
 begin;
 
-select plan(13);
+select plan(14);
 
 -- ---------------------------------------------------------------------------
 -- Fixtures (Hotel A = staff's own hotel, Hotel B = a foreign hotel)
@@ -142,6 +142,14 @@ select cmp_ok(
   (select count(*)::int from public.rooms where is_available = true),
   '>=', 6,
   'Guest can browse available rooms broadly'
+);
+
+-- ...but a guest cannot see a seeded UNAVAILABLE room (Lima's City View 102).
+select is(
+  (select count(*)::int from public.rooms
+     where id = '20000000-0000-0000-0000-000000000002'),
+  0,
+  'Guest cannot see an unavailable room'
 );
 
 -- Boundary #6: a guest cannot read a reservation that is not theirs, even at a


### PR DESCRIPTION
## Summary

Establishes the Postgres data foundation for **EPIC-02 · Data model & Postgres schema** (BE-201–204). Pure DB layer: migrations, seed, and an automated RLS test — no `apps/` code touches Supabase.

- **BE-201 (#159) · Core schema** — normalized `hotels`, `rooms`, `reservations`, `profiles` tables, each with `created_at`/`updated_at` (auto-maintained by an `updated_at` trigger). `profiles` extends `auth.users` (FK on `id`) with a `role` enum (`guest`/`hotel_staff`/`admin`) and a nullable `hotel_id` ownership link. `reservations.status` is a DB-level enum (`held`/`confirmed`/`cancelled`/`rejected`/`expired`). All FKs and `NOT NULL`s are explicit (no orphan rooms), and there's an index on `reservations(hotel_id, status, created_at)` for the BE-304 ranking query.
- **BE-202 (#160) · PostGIS** — `hotels.location geometry(Point, 4326)` with a GiST index; PostGIS is enabled in-migration so a from-scratch reset works. Adds a **functional geography GiST index** so metre-accurate `ST_DWithin` proximity search is index-accelerated (verified via `EXPLAIN`) rather than degree-based.
- **BE-203 (#161) · RLS** — RLS enabled on all four tables. Hotel staff read/write only their own hotel's rooms/reservations; guests browse available rooms broadly but can only insert/update reservations in their own name (and only into the `held` state). `role`/`hotel_id` are **not** granted to `authenticated`, closing a privilege-escalation path. Policy intent is commented; a pgTAP test proves the cross-tenant boundary.
- **BE-204 (#162) · Seed** — idempotent, deterministic `seed.sql`: six real launch-city hotels (Lima, Mexico City, Bogotá, Buenos Aires, New York, Miami), a mix of available/unavailable rooms, and test `guest@hotelyn.test` / `staff@hotelyn.test` accounts.

A composite `(room_id, hotel_id)` FK guarantees a reservation's room and hotel can never disagree (tenant-scoping integrity).

**Review note:** CodeRabbit's suggestion of a `btree_gist` exclusion constraint to prevent overlapping bookings was intentionally deferred — booking-conflict handling belongs to the reservation-workflow epic, not the schema foundation.

Closes #159
Closes #160
Closes #161
Closes #162

## Test plan

- [x] `supabase db reset` applies schema + seed cleanly from scratch
- [x] `supabase test db` — pgTAP RLS suite passes (13 assertions)
- [x] Hotel A staff sees/writes zero of Hotel B's rooms & reservations (SELECT/INSERT/UPDATE/DELETE)
- [x] Guest can browse available rooms; cannot read others' reservations; cannot book in another's name; cannot self-escalate `role`
- [x] `ST_DWithin` returns the expected hotel for a known point and uses the geography GiST index (`EXPLAIN`)
- [x] Composite FK rejects a reservation whose room belongs to a different hotel

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an updated local setup guide with a deterministic database reset flow and seeded verification.
  * Documented the Supabase data model (profiles, hotels, rooms, reservations), including location-based proximity search behavior.
  * Added seeded demo data for consistent local development and testing.
* **Security**
  * Implemented full RLS policies for hotels, rooms, reservations, and profiles, with tenant-scoped staff access and protected profile fields.
* **Bug Fixes**
  * Added foundational schema constraints and lifecycle/status handling to strengthen booking and room integrity.
* **Tests**
  * Added automated RLS tests to confirm isolation boundaries for guest and hotel staff actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->