### PR TITLE
feat(geo): nearby/recommended hotels + room availability (GraphQL)

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,12 +144,47 @@ where st_dwithin(location::geography,
                  st_setsrid(st_makepoint(-77.03, -12.11), 4326)::geography, 5000);
 ```
 
-The RLS policies are covered by an automated pgTAP test that proves a Hotel A
-staff session cannot read or write Hotel B's data:
+The RLS policies (and the geolocation functions below) are covered by automated
+pgTAP tests — the Hotel A / Hotel B isolation proof plus the search-function
+behaviour:
 
 ```bash
 supabase test db
 ```
+
+### Geolocation search & recommendations
+
+Three SECURITY DEFINER SQL functions (migration `..._geo_search.sql`) power
+search. They read every reservation to compute availability but only ever return
+public catalogue rows:
+
+| Function | Purpose |
+| -------- | ------- |
+| `nearby_hotels(lat, lng, radius_km)` | Hotels within the radius (`ST_DWithin`), nearest-first with a `distance_km` (`ST_Distance`). Empty set when nothing is in range. |
+| `rooms_with_availability(hotel_id?)` | Each room with `available_now` = flagged available **and** no unexpired `held`/`confirmed` hold (`hold_expires_at > now()`). Expired holds don't block. |
+| `recommended_hotels(lat, lng, radius_km)` | In-radius hotels ranked by `confirmed` reservations in the trailing `recommendation_window_days()` (30), ties broken by proximity. Cold-start (all zero) falls back to nearby filtered to available-now. |
+
+Nearby search is index-accelerated: **p95 ≈ 0.3 ms with 100 hotels** (200 runs,
+local stack) — well under the 300 ms budget.
+
+### GraphQL API (Dart Frog)
+
+The `backend/` Dart Frog server exposes these over a single `POST /graphql`
+endpoint (`nearbyHotels`, `recommendedHotels`, `roomsAvailability`), resolving
+each through a Supabase-backed data client — the Flutter apps never call Supabase
+directly. Run it with the local stack up:
+
+```bash
+cd backend && dart_frog dev   # http://localhost:8080/graphql
+```
+
+```bash
+curl http://localhost:8080/graphql -H 'Content-Type: application/json' -X POST \
+  -d '{"query":"{ nearbyHotels(lat: -12.11, lng: -77.03, radiusKm: 200.0) { name city distanceKm } }"}'
+```
+
+> `lat`/`lng`/`radiusKm` are GraphQL `Float`s — send them as decimals
+> (`200.0`, not `200`).
 
 ### Email testing (local)
 

--- a/apps/hotelyn_app/pubspec.yaml
+++ b/apps/hotelyn_app/pubspec.yaml
@@ -40,7 +40,9 @@ dev_dependencies:
   melos: ^7.3.0
   mocktail: ^1.0.3
   riverpod_lint: ^3.0.3
-  test: ^1.31.0
+  # Pinned to the version bundled with the Flutter SDK (test_api 0.7.10); newer
+  # `test` releases require a test_api the SDK's flutter_test does not allow. See #225.
+  test: 1.30.0
   very_good_analysis: ^10.0.0
 
 fonts:

--- a/backend/lib/hotelyn_server.dart
+++ b/backend/lib/hotelyn_server.dart
@@ -1,2 +1,5 @@
 /// Dart Frog GraphQL server for Hotelyn.
 library;
+
+export 'src/data/hotel_data_client.dart';
+export 'src/graphql/hotel_graphql.dart';

--- a/backend/lib/src/data/hotel_data_client.dart
+++ b/backend/lib/src/data/hotel_data_client.dart
@@ -1,0 +1,118 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:supabase/supabase.dart';
+
+/// Read-only access to Hotelyn's geolocation-search data.
+///
+/// This is the single seam through which the GraphQL layer reaches Supabase;
+/// no `supabase` call originates outside an implementation of this interface.
+abstract class HotelDataClient {
+  /// Hotels within [radiusKm] of ([lat], [lng]), nearest-first
+  /// (via `nearby_hotels`).
+  Future<List<Hotel>> nearbyHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  });
+
+  /// Popular-yet-nearby hotels within [radiusKm] (`recommended_hotels`).
+  Future<List<Hotel>> recommendedHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  });
+
+  /// Rooms (optionally for a single [hotelId]) with computed `available_now`
+  /// (`rooms_with_availability`).
+  Future<List<Room>> roomsAvailability({String? hotelId});
+}
+
+/// [HotelDataClient] backed by Supabase RPC calls to the SQL functions.
+class SupabaseHotelDataClient implements HotelDataClient {
+  const SupabaseHotelDataClient(this._client);
+
+  final SupabaseClient _client;
+
+  @override
+  Future<List<Hotel>> nearbyHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) =>
+      _hotelsFromRpc('nearby_hotels', lat: lat, lng: lng, radiusKm: radiusKm);
+
+  @override
+  Future<List<Hotel>> recommendedHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) =>
+      _hotelsFromRpc(
+        'recommended_hotels',
+        lat: lat,
+        lng: lng,
+        radiusKm: radiusKm,
+      );
+
+  /// Shared radius-search plumbing: `nearby_hotels` and `recommended_hotels`
+  /// take the same params and row shape, differing only in ranking.
+  Future<List<Hotel>> _hotelsFromRpc(
+    String function, {
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async {
+    final rows = await _client.rpc<List<dynamic>>(
+      function,
+      params: {'lat': lat, 'lng': lng, 'radius_km': radiusKm},
+    );
+    return rows
+        .map((row) => hotelFromRow(row as Map<String, dynamic>))
+        .toList();
+  }
+
+  @override
+  Future<List<Room>> roomsAvailability({String? hotelId}) async {
+    final rows = await _client.rpc<List<dynamic>>(
+      'rooms_with_availability',
+      params: {'p_hotel_id': hotelId},
+    );
+    return rows.map((row) => roomFromRow(row as Map<String, dynamic>)).toList();
+  }
+}
+
+/// Maps a `nearby_hotels` / `recommended_hotels` result row to a [Hotel].
+///
+/// Kept as a pure top-level function so it is unit-testable without a live
+/// Supabase connection.
+Hotel hotelFromRow(Map<String, dynamic> row) {
+  return Hotel(
+    id: row['id'] as String,
+    name: row['name'] as String,
+    city: row['city'] as String,
+    country: row['country'] as String,
+    description: row['description'] as String?,
+    address: row['address'] as String?,
+    latitude: _toDouble(row['latitude']),
+    longitude: _toDouble(row['longitude']),
+    distanceKm: _toDouble(row['distance_km']),
+    popularity: (row['popularity'] as num?)?.toInt(),
+  );
+}
+
+/// Maps a `rooms_with_availability` result row to a [Room].
+Room roomFromRow(Map<String, dynamic> row) {
+  return Room(
+    id: row['id'] as String,
+    hotelId: row['hotel_id'] as String,
+    name: row['name'] as String,
+    roomType: row['room_type'] as String,
+    capacity: (row['capacity'] as num).toInt(),
+    // price_per_night is NOT NULL in the schema; parse it directly so a missing
+    // value surfaces as an error rather than a silent "free" room.
+    pricePerNight: (row['price_per_night'] as num).toDouble(),
+    isAvailable: row['is_available'] as bool,
+    availableNow: row['available_now'] as bool,
+  );
+}
+
+double? _toDouble(Object? value) => (value as num?)?.toDouble();

--- a/backend/lib/src/graphql/hotel_graphql.dart
+++ b/backend/lib/src/graphql/hotel_graphql.dart
@@ -1,0 +1,146 @@
+import 'package:graphql_schema2/graphql_schema2.dart';
+import 'package:graphql_server2/graphql_server2.dart';
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:hotelyn_server/src/data/hotel_data_client.dart';
+
+/// The `Hotel` GraphQL type. Field resolvers read straight off the domain
+/// entity; search-only projections (`distanceKm`, `popularity`) are nullable.
+GraphQLObjectType _hotelType() {
+  return objectType(
+    'Hotel',
+    fields: [
+      field('id', graphQLId, resolve: (obj, _) => (obj as Hotel).id),
+      field('name', graphQLString, resolve: (obj, _) => (obj as Hotel).name),
+      field(
+        'description',
+        graphQLString,
+        resolve: (obj, _) => (obj as Hotel).description,
+      ),
+      field(
+        'address',
+        graphQLString,
+        resolve: (obj, _) => (obj as Hotel).address,
+      ),
+      field('city', graphQLString, resolve: (obj, _) => (obj as Hotel).city),
+      field(
+        'country',
+        graphQLString,
+        resolve: (obj, _) => (obj as Hotel).country,
+      ),
+      field(
+        'latitude',
+        graphQLFloat,
+        resolve: (obj, _) => (obj as Hotel).latitude,
+      ),
+      field(
+        'longitude',
+        graphQLFloat,
+        resolve: (obj, _) => (obj as Hotel).longitude,
+      ),
+      field(
+        'distanceKm',
+        graphQLFloat,
+        resolve: (obj, _) => (obj as Hotel).distanceKm,
+      ),
+      field(
+        'popularity',
+        graphQLInt,
+        resolve: (obj, _) => (obj as Hotel).popularity,
+      ),
+    ],
+  );
+}
+
+/// The `Room` GraphQL type.
+GraphQLObjectType _roomType() {
+  return objectType(
+    'Room',
+    fields: [
+      field('id', graphQLId, resolve: (obj, _) => (obj as Room).id),
+      field('hotelId', graphQLId, resolve: (obj, _) => (obj as Room).hotelId),
+      field('name', graphQLString, resolve: (obj, _) => (obj as Room).name),
+      field(
+        'roomType',
+        graphQLString,
+        resolve: (obj, _) => (obj as Room).roomType,
+      ),
+      field(
+        'capacity',
+        graphQLInt,
+        resolve: (obj, _) => (obj as Room).capacity,
+      ),
+      field(
+        'pricePerNight',
+        graphQLFloat,
+        resolve: (obj, _) => (obj as Room).pricePerNight,
+      ),
+      field(
+        'isAvailable',
+        graphQLBoolean,
+        resolve: (obj, _) => (obj as Room).isAvailable,
+      ),
+      field(
+        'availableNow',
+        graphQLBoolean,
+        resolve: (obj, _) => (obj as Room).availableNow,
+      ),
+    ],
+  );
+}
+
+double _requireDouble(Object? value) => (value! as num).toDouble();
+
+/// Builds the read-only query schema, wiring each query to [client].
+GraphQLSchema buildHotelSchema(HotelDataClient client) {
+  final hotelType = _hotelType();
+  final roomType = _roomType();
+
+  return graphQLSchema(
+    queryType: objectType(
+      'Query',
+      fields: [
+        field(
+          'nearbyHotels',
+          listOf(hotelType),
+          inputs: [
+            GraphQLFieldInput('lat', graphQLFloat.nonNullable()),
+            GraphQLFieldInput('lng', graphQLFloat.nonNullable()),
+            GraphQLFieldInput('radiusKm', graphQLFloat.nonNullable()),
+          ],
+          resolve: (_, args) => client.nearbyHotels(
+            lat: _requireDouble(args['lat']),
+            lng: _requireDouble(args['lng']),
+            radiusKm: _requireDouble(args['radiusKm']),
+          ),
+        ),
+        field(
+          'recommendedHotels',
+          listOf(hotelType),
+          inputs: [
+            GraphQLFieldInput('lat', graphQLFloat.nonNullable()),
+            GraphQLFieldInput('lng', graphQLFloat.nonNullable()),
+            GraphQLFieldInput('radiusKm', graphQLFloat.nonNullable()),
+          ],
+          resolve: (_, args) => client.recommendedHotels(
+            lat: _requireDouble(args['lat']),
+            lng: _requireDouble(args['lng']),
+            radiusKm: _requireDouble(args['radiusKm']),
+          ),
+        ),
+        field(
+          'roomsAvailability',
+          listOf(roomType),
+          inputs: [
+            GraphQLFieldInput('hotelId', graphQLId),
+          ],
+          resolve: (_, args) =>
+              client.roomsAvailability(hotelId: args['hotelId'] as String?),
+        ),
+      ],
+    ),
+  );
+}
+
+/// Builds a ready-to-execute [GraphQL] instance for [client].
+GraphQL buildGraphQL(HotelDataClient client) =>
+    GraphQL(buildHotelSchema(client));

--- a/backend/pubspec.yaml
+++ b/backend/pubspec.yaml
@@ -8,6 +8,15 @@ resolution: workspace
 environment:
   sdk: ">=3.5.0 <4.0.0"
 
+dependencies:
+  dart_frog: ^1.2.0
+  graphql_schema2: ^6.5.0
+  graphql_server2: ^6.5.0
+  hotelyn_domain: any
+  supabase: ^2.14.0
+
 dev_dependencies:
-  test: ^1.31.0
+  mocktail: ^1.0.0
+  # Pinned to the version bundled with the Flutter SDK (test_api 0.7.10); see #225.
+  test: 1.30.0
   very_good_analysis: ^10.0.0

--- a/backend/routes/_middleware.dart
+++ b/backend/routes/_middleware.dart
@@ -1,0 +1,36 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:hotelyn_server/hotelyn_server.dart';
+import 'package:supabase/supabase.dart';
+
+HotelDataClient? _dataClient;
+
+/// Builds the Supabase-backed data client from the environment, once.
+///
+/// The server talks to Supabase with the service-role key; that key never
+/// reaches a Flutter client. `SUPABASE_URL` falls back to the local-stack
+/// default, but the service-role key must be provided explicitly (copy it from
+/// `supabase status`) — defaulting it would silently hide a misconfiguration,
+/// and every query would then fail at request time instead.
+HotelDataClient _resolveDataClient() {
+  final serviceRoleKey = Platform.environment['SUPABASE_SERVICE_ROLE_KEY'];
+  if (serviceRoleKey == null || serviceRoleKey.isEmpty) {
+    throw StateError(
+      'SUPABASE_SERVICE_ROLE_KEY must be set to a valid service-role key '
+      '(see `supabase status`).',
+    );
+  }
+  return _dataClient ??= SupabaseHotelDataClient(
+    SupabaseClient(
+      Platform.environment['SUPABASE_URL'] ?? 'http://127.0.0.1:54321',
+      serviceRoleKey,
+    ),
+  );
+}
+
+Handler middleware(Handler handler) {
+  return handler.use(
+    provider<HotelDataClient>((_) => _resolveDataClient()),
+  );
+}

--- a/backend/routes/graphql.dart
+++ b/backend/routes/graphql.dart
@@ -1,0 +1,71 @@
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:graphql_schema2/graphql_schema2.dart';
+import 'package:hotelyn_server/hotelyn_server.dart';
+
+/// Single GraphQL endpoint. Accepts a JSON body of the shape
+/// `{ "query": "...", "variables": { ... } }` over POST and returns
+/// `{ "data": ... }` (or `{ "errors": [...] }` on an invalid query).
+Future<Response> onRequest(RequestContext context) async {
+  if (context.request.method != HttpMethod.post) {
+    return Response(statusCode: HttpStatus.methodNotAllowed);
+  }
+
+  final dynamic body;
+  try {
+    body = await context.request.json();
+  } on FormatException {
+    return _badRequest('Request body must be valid JSON.');
+  }
+
+  if (body is! Map<String, dynamic> || body['query'] is! String) {
+    return _badRequest('Body must be JSON with a "query" string field.');
+  }
+
+  final rawVariables = body['variables'];
+  if (rawVariables != null && rawVariables is! Map<String, dynamic>) {
+    return _badRequest('"variables" must be a JSON object.');
+  }
+
+  final query = body['query'] as String;
+  final variables = (rawVariables as Map<String, dynamic>?) ?? const {};
+
+  final graphQL = buildGraphQL(context.read<HotelDataClient>());
+
+  try {
+    final data =
+        await graphQL.parseAndExecute(query, variableValues: variables);
+    return Response.json(body: {'data': data});
+  } on GraphQLException catch (error) {
+    // Invalid query / variables: a client (400) error.
+    return Response.json(
+      statusCode: HttpStatus.badRequest,
+      body: {
+        'errors': error.errors.map((e) => {'message': e.message}).toList(),
+      },
+    );
+  } on Object {
+    // Resolver / data-layer failure (e.g. Supabase unreachable): a server error.
+    // The internal detail is deliberately not leaked to the client.
+    return Response.json(
+      statusCode: HttpStatus.internalServerError,
+      body: {
+        'errors': [
+          {'message': 'Unexpected error while executing the query.'},
+        ],
+      },
+    );
+  }
+}
+
+Response _badRequest(String message) {
+  return Response.json(
+    statusCode: HttpStatus.badRequest,
+    body: {
+      'errors': [
+        {'message': message},
+      ],
+    },
+  );
+}

--- a/backend/test/data/hotel_data_client_test.dart
+++ b/backend/test/data/hotel_data_client_test.dart
@@ -1,0 +1,90 @@
+import 'package:hotelyn_server/hotelyn_server.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('hotelFromRow', () {
+    test('maps a full nearby/recommended row into a Hotel', () {
+      final hotel = hotelFromRow({
+        'id': 'h1',
+        'name': 'Miraflores Bay Hotel',
+        'description': 'Oceanfront',
+        'address': 'Malecon 615',
+        'city': 'Lima',
+        'country': 'Peru',
+        'latitude': -12.1219,
+        'longitude': -77.0428,
+        'distance_km': 1.9,
+        'popularity': 3,
+      });
+
+      expect(hotel.id, 'h1');
+      expect(hotel.name, 'Miraflores Bay Hotel');
+      expect(hotel.city, 'Lima');
+      expect(hotel.country, 'Peru');
+      expect(hotel.latitude, closeTo(-12.1219, 1e-9));
+      expect(hotel.longitude, closeTo(-77.0428, 1e-9));
+      expect(hotel.distanceKm, closeTo(1.9, 1e-9));
+      expect(hotel.popularity, 3);
+    });
+
+    test('tolerates nullable projections and integer coordinates', () {
+      final hotel = hotelFromRow({
+        'id': 'h2',
+        'name': 'Reforma Grand',
+        'description': null,
+        'address': null,
+        'city': 'Mexico City',
+        'country': 'Mexico',
+        'latitude': 19, // integer from JSON
+        'longitude': -99,
+        'distance_km': null,
+        'popularity': null,
+      });
+
+      expect(hotel.description, isNull);
+      expect(hotel.address, isNull);
+      expect(hotel.distanceKm, isNull);
+      expect(hotel.popularity, isNull);
+      expect(hotel.latitude, 19.0);
+      expect(hotel.longitude, -99.0);
+    });
+  });
+
+  group('roomFromRow', () {
+    test('maps a rooms_with_availability row into a Room', () {
+      final room = roomFromRow({
+        'id': 'r1',
+        'hotel_id': 'h1',
+        'name': 'Ocean View 101',
+        'room_type': 'double',
+        'capacity': 2,
+        'price_per_night': 180.0,
+        'is_available': true,
+        'available_now': false,
+      });
+
+      expect(room.id, 'r1');
+      expect(room.hotelId, 'h1');
+      expect(room.roomType, 'double');
+      expect(room.capacity, 2);
+      expect(room.pricePerNight, 180.0);
+      expect(room.isAvailable, isTrue);
+      expect(room.availableNow, isFalse);
+    });
+
+    test('coerces an integer price into a double', () {
+      final room = roomFromRow({
+        'id': 'r2',
+        'hotel_id': 'h1',
+        'name': 'City View 102',
+        'room_type': 'single',
+        'capacity': 1,
+        'price_per_night': 90, // integer from JSON
+        'is_available': false,
+        'available_now': false,
+      });
+
+      expect(room.pricePerNight, 90.0);
+    });
+  });
+}

--- a/backend/test/graphql/hotel_graphql_test.dart
+++ b/backend/test/graphql/hotel_graphql_test.dart
@@ -1,0 +1,190 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:hotelyn_server/hotelyn_server.dart';
+import 'package:test/test.dart';
+
+/// In-memory [HotelDataClient] that records the arguments it was called with
+/// and returns canned domain entities, so the schema/resolvers can be exercised
+/// without a live Supabase connection.
+class _FakeHotelDataClient implements HotelDataClient {
+  _FakeHotelDataClient({
+    this.hotels = const [],
+    this.recommended = const [],
+    this.rooms = const [],
+  });
+
+  final List<Hotel> hotels;
+  final List<Hotel> recommended;
+  final List<Room> rooms;
+
+  double? lastLat;
+  double? lastLng;
+  double? lastRadiusKm;
+  String? lastHotelId;
+  bool roomsCalled = false;
+
+  @override
+  Future<List<Hotel>> nearbyHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async {
+    lastLat = lat;
+    lastLng = lng;
+    lastRadiusKm = radiusKm;
+    return hotels;
+  }
+
+  @override
+  Future<List<Hotel>> recommendedHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async {
+    lastLat = lat;
+    lastLng = lng;
+    lastRadiusKm = radiusKm;
+    return recommended;
+  }
+
+  @override
+  Future<List<Room>> roomsAvailability({String? hotelId}) async {
+    roomsCalled = true;
+    lastHotelId = hotelId;
+    return rooms;
+  }
+}
+
+void main() {
+  group('buildGraphQL', () {
+    test('nearbyHotels resolves rows and forwards the radius args', () async {
+      final client = _FakeHotelDataClient(
+        hotels: const [
+          Hotel(
+            id: 'h1',
+            name: 'Miraflores Bay Hotel',
+            city: 'Lima',
+            country: 'Peru',
+            latitude: -12.12,
+            longitude: -77.04,
+            distanceKm: 1.9,
+          ),
+        ],
+      );
+      final graphQL = buildGraphQL(client);
+
+      final data = await graphQL.parseAndExecute(
+        '{ nearbyHotels(lat: -12.11, lng: -77.03, radiusKm: 200.0) '
+        '{ id name city distanceKm } }',
+      ) as Map<String, dynamic>;
+
+      expect(client.lastLat, closeTo(-12.11, 1e-9));
+      expect(client.lastLng, closeTo(-77.03, 1e-9));
+      expect(client.lastRadiusKm, closeTo(200, 1e-9));
+
+      final rows = data['nearbyHotels'] as List<dynamic>;
+      expect(rows, hasLength(1));
+      expect(
+        rows.first,
+        {
+          'id': 'h1',
+          'name': 'Miraflores Bay Hotel',
+          'city': 'Lima',
+          'distanceKm': 1.9,
+        },
+      );
+    });
+
+    test('nearbyHotels returns an empty list when nothing is in range',
+        () async {
+      final graphQL = buildGraphQL(_FakeHotelDataClient());
+
+      final data = await graphQL.parseAndExecute(
+        '{ nearbyHotels(lat: 0.0, lng: 0.0, radiusKm: 10.0) { id } }',
+      ) as Map<String, dynamic>;
+
+      expect(data['nearbyHotels'], isEmpty);
+    });
+
+    test('recommendedHotels exposes the popularity projection', () async {
+      final client = _FakeHotelDataClient(
+        recommended: const [
+          Hotel(
+            id: 'h1',
+            name: 'Zona Rosa Suites',
+            city: 'Bogota',
+            country: 'Colombia',
+            distanceKm: 5,
+            popularity: 2,
+          ),
+        ],
+      );
+      final graphQL = buildGraphQL(client);
+
+      final data = await graphQL.parseAndExecute(
+        '{ recommendedHotels(lat: 4.7, lng: -74.0, radiusKm: 50.0) '
+        '{ id popularity } }',
+      ) as Map<String, dynamic>;
+
+      final rows = data['recommendedHotels'] as List<dynamic>;
+      expect(rows.first, {'id': 'h1', 'popularity': 2});
+    });
+
+    test('roomsAvailability forwards the hotelId and maps availableNow',
+        () async {
+      final client = _FakeHotelDataClient(
+        rooms: const [
+          Room(
+            id: 'r1',
+            hotelId: 'h1',
+            name: 'Ocean View 101',
+            roomType: 'double',
+            capacity: 2,
+            pricePerNight: 180,
+            isAvailable: true,
+            availableNow: false,
+          ),
+        ],
+      );
+      final graphQL = buildGraphQL(client);
+
+      final data = await graphQL.parseAndExecute(
+        '{ roomsAvailability(hotelId: "h1") '
+        '{ id availableNow pricePerNight } }',
+      ) as Map<String, dynamic>;
+
+      expect(client.roomsCalled, isTrue);
+      expect(client.lastHotelId, 'h1');
+      final rows = data['roomsAvailability'] as List<dynamic>;
+      expect(rows.first, {
+        'id': 'r1',
+        'availableNow': false,
+        'pricePerNight': 180.0,
+      });
+    });
+
+    test('rejects a query that omits a required radius argument', () async {
+      final graphQL = buildGraphQL(_FakeHotelDataClient());
+
+      expect(
+        () => graphQL.parseAndExecute('{ nearbyHotels(lat: 1.0, lng: 2.0) '
+            '{ id } }'),
+        throwsA(anything),
+      );
+    });
+
+    test('supports query variables', () async {
+      final client = _FakeHotelDataClient();
+      final graphQL = buildGraphQL(client);
+
+      await graphQL.parseAndExecute(
+        r'query Nearby($lat: Float!, $lng: Float!, $r: Float!) '
+        r'{ nearbyHotels(lat: $lat, lng: $lng, radiusKm: $r) { id } }',
+        variableValues: const {'lat': 25.76, 'lng': -80.19, 'r': 12.5},
+      );
+
+      expect(client.lastLat, closeTo(25.76, 1e-9));
+      expect(client.lastLng, closeTo(-80.19, 1e-9));
+      expect(client.lastRadiusKm, closeTo(12.5, 1e-9));
+    });
+  });
+}

--- a/backend/test/routes/graphql_test.dart
+++ b/backend/test/routes/graphql_test.dart
@@ -1,0 +1,121 @@
+import 'dart:convert';
+import 'dart:io';
+
+import 'package:dart_frog/dart_frog.dart';
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:hotelyn_server/hotelyn_server.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:test/test.dart';
+
+import '../../routes/graphql.dart' as route;
+
+class _MockRequestContext extends Mock implements RequestContext {}
+
+class _MockRequest extends Mock implements Request {}
+
+class _FakeHotelDataClient implements HotelDataClient {
+  @override
+  Future<List<Hotel>> nearbyHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async =>
+      const [
+        Hotel(id: 'h1', name: 'Miraflores', city: 'Lima', country: 'Peru'),
+      ];
+
+  @override
+  Future<List<Hotel>> recommendedHotels({
+    required double lat,
+    required double lng,
+    required double radiusKm,
+  }) async =>
+      const [];
+
+  @override
+  Future<List<Room>> roomsAvailability({String? hotelId}) async => const [];
+}
+
+void main() {
+  late _MockRequestContext context;
+  late _MockRequest request;
+
+  setUp(() {
+    context = _MockRequestContext();
+    request = _MockRequest();
+    when(() => context.request).thenReturn(request);
+    when(() => context.read<HotelDataClient>())
+        .thenReturn(_FakeHotelDataClient());
+  });
+
+  test('rejects non-POST methods with 405', () async {
+    when(() => request.method).thenReturn(HttpMethod.get);
+
+    final response = await route.onRequest(context);
+
+    expect(response.statusCode, HttpStatus.methodNotAllowed);
+  });
+
+  test('rejects a body without a query field with 400', () async {
+    when(() => request.method).thenReturn(HttpMethod.post);
+    when(request.json).thenAnswer((_) async => <String, dynamic>{});
+
+    final response = await route.onRequest(context);
+
+    expect(response.statusCode, HttpStatus.badRequest);
+  });
+
+  test('executes a valid query and returns data', () async {
+    when(() => request.method).thenReturn(HttpMethod.post);
+    when(request.json).thenAnswer(
+      (_) async => {
+        'query': '{ nearbyHotels(lat: -12.11, lng: -77.03, radiusKm: 200.0) '
+            '{ id name } }',
+      },
+    );
+
+    final response = await route.onRequest(context);
+    expect(response.statusCode, HttpStatus.ok);
+
+    final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+    final data = body['data'] as Map<String, dynamic>;
+    final rows = data['nearbyHotels'] as List<dynamic>;
+    expect(rows.first, {'id': 'h1', 'name': 'Miraflores'});
+  });
+
+  test('returns 400 when the JSON body is malformed', () async {
+    when(() => request.method).thenReturn(HttpMethod.post);
+    when(request.json).thenThrow(const FormatException('bad json'));
+
+    final response = await route.onRequest(context);
+
+    expect(response.statusCode, HttpStatus.badRequest);
+    final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+    expect(body['errors'], isNotEmpty);
+  });
+
+  test('returns 400 when variables is not an object', () async {
+    when(() => request.method).thenReturn(HttpMethod.post);
+    when(request.json).thenAnswer(
+      (_) async => {'query': '{ nearbyHotels { id } }', 'variables': 'nope'},
+    );
+
+    final response = await route.onRequest(context);
+
+    expect(response.statusCode, HttpStatus.badRequest);
+  });
+
+  test('returns 400 with errors for a malformed query', () async {
+    when(() => request.method).thenReturn(HttpMethod.post);
+    when(request.json).thenAnswer(
+      // Unterminated selection set — a parse error surfaced as a GraphQL error.
+      (_) async => {'query': '{ nearbyHotels(lat: 1.0'},
+    );
+
+    final response = await route.onRequest(context);
+
+    expect(response.statusCode, HttpStatus.badRequest);
+    final body = jsonDecode(await response.body()) as Map<String, dynamic>;
+    expect(body['errors'], isNotEmpty);
+  });
+}

--- a/packages/hotelyn_domain/lib/hotelyn_domain.dart
+++ b/packages/hotelyn_domain/lib/hotelyn_domain.dart
@@ -1,2 +1,5 @@
 /// Domain entities and repository interfaces for Hotelyn.
 library;
+
+export 'src/hotel.dart';
+export 'src/room.dart';

--- a/packages/hotelyn_domain/lib/src/hotel.dart
+++ b/packages/hotelyn_domain/lib/src/hotel.dart
@@ -1,0 +1,52 @@
+import 'package:equatable/equatable.dart';
+
+/// A hotel in the Hotelyn catalogue.
+///
+/// [distanceKm] and [popularity] are search projections: they are only
+/// populated by the geolocation search functions (`nearby_hotels` /
+/// `recommended_hotels`) and are `null` for a plain catalogue lookup.
+class Hotel extends Equatable {
+  const Hotel({
+    required this.id,
+    required this.name,
+    required this.city,
+    required this.country,
+    this.description,
+    this.address,
+    this.latitude,
+    this.longitude,
+    this.distanceKm,
+    this.popularity,
+  });
+
+  final String id;
+  final String name;
+  final String city;
+  final String country;
+  final String? description;
+  final String? address;
+  final double? latitude;
+  final double? longitude;
+
+  /// Great-circle distance in kilometres from the query point, when returned by
+  /// a proximity search. `null` otherwise.
+  final double? distanceKm;
+
+  /// Count of qualifying confirmed reservations in the recommendation window,
+  /// when returned by `recommended_hotels`. `null` otherwise.
+  final int? popularity;
+
+  @override
+  List<Object?> get props => [
+        id,
+        name,
+        city,
+        country,
+        description,
+        address,
+        latitude,
+        longitude,
+        distanceKm,
+        popularity,
+      ];
+}

--- a/packages/hotelyn_domain/lib/src/room.dart
+++ b/packages/hotelyn_domain/lib/src/room.dart
@@ -1,0 +1,40 @@
+import 'package:equatable/equatable.dart';
+
+/// A bookable room belonging to a hotel.
+///
+/// [isAvailable] is the room's static flag; [availableNow] also accounts for
+/// active (unexpired) holds and confirmed bookings — see the `available_now`
+/// computation (BE-302).
+class Room extends Equatable {
+  const Room({
+    required this.id,
+    required this.hotelId,
+    required this.name,
+    required this.roomType,
+    required this.capacity,
+    required this.pricePerNight,
+    required this.isAvailable,
+    required this.availableNow,
+  });
+
+  final String id;
+  final String hotelId;
+  final String name;
+  final String roomType;
+  final int capacity;
+  final double pricePerNight;
+  final bool isAvailable;
+  final bool availableNow;
+
+  @override
+  List<Object?> get props => [
+        id,
+        hotelId,
+        name,
+        roomType,
+        capacity,
+        pricePerNight,
+        isAvailable,
+        availableNow,
+      ];
+}

--- a/packages/hotelyn_domain/pubspec.yaml
+++ b/packages/hotelyn_domain/pubspec.yaml
@@ -12,5 +12,8 @@ dependencies:
   equatable: ^2.0.8
 
 dev_dependencies:
-  test: ^1.31.0
+  # Pinned to the version bundled with the Flutter SDK (test_api 0.7.10); newer
+  # `test` releases require a test_api the SDK's flutter_test does not allow,
+  # which breaks workspace-wide resolution. See #225.
+  test: 1.30.0
   very_good_analysis: ^10.0.0

--- a/packages/hotelyn_domain/test/hotel_test.dart
+++ b/packages/hotelyn_domain/test/hotel_test.dart
@@ -1,0 +1,71 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Hotel', () {
+    test('supports value equality', () {
+      const a = Hotel(id: 'h1', name: 'Bay', city: 'Lima', country: 'Peru');
+      const b = Hotel(id: 'h1', name: 'Bay', city: 'Lima', country: 'Peru');
+      expect(a, equals(b));
+    });
+
+    test('differs when a search projection differs', () {
+      const a = Hotel(id: 'h1', name: 'Bay', city: 'Lima', country: 'Peru');
+      const b = Hotel(
+        id: 'h1',
+        name: 'Bay',
+        city: 'Lima',
+        country: 'Peru',
+        distanceKm: 1.9,
+      );
+      expect(a, isNot(equals(b)));
+    });
+
+    test('leaves search projections null by default', () {
+      const hotel = Hotel(id: 'h1', name: 'Bay', city: 'Lima', country: 'Peru');
+      expect(hotel.distanceKm, isNull);
+      expect(hotel.popularity, isNull);
+    });
+  });
+
+  group('Room', () {
+    test('supports value equality', () {
+      const a = Room(
+        id: 'r1',
+        hotelId: 'h1',
+        name: '101',
+        roomType: 'double',
+        capacity: 2,
+        pricePerNight: 180,
+        isAvailable: true,
+        availableNow: true,
+      );
+      const b = Room(
+        id: 'r1',
+        hotelId: 'h1',
+        name: '101',
+        roomType: 'double',
+        capacity: 2,
+        pricePerNight: 180,
+        isAvailable: true,
+        availableNow: true,
+      );
+      expect(a, equals(b));
+    });
+
+    test('distinguishes availableNow from isAvailable', () {
+      const room = Room(
+        id: 'r1',
+        hotelId: 'h1',
+        name: '101',
+        roomType: 'double',
+        capacity: 2,
+        pricePerNight: 180,
+        isAvailable: true,
+        availableNow: false,
+      );
+      expect(room.isAvailable, isTrue);
+      expect(room.availableNow, isFalse);
+    });
+  });
+}

--- a/packages/hotelyn_gql/pubspec.yaml
+++ b/packages/hotelyn_gql/pubspec.yaml
@@ -9,5 +9,6 @@ environment:
   sdk: ">=3.5.0 <4.0.0"
 
 dev_dependencies:
-  test: ^1.31.0
+  # Pinned to the version bundled with the Flutter SDK (test_api 0.7.10); see #225.
+  test: 1.30.0
   very_good_analysis: ^10.0.0

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,6 +41,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.13.10"
+  angel3_model:
+    dependency: transitive
+    description:
+      name: angel3_model
+      sha256: f0629b5a552450a9a242e3d0838b2b1521e1c38aa59620ec7e3789acb858a71b
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.4.0"
+  angel3_serialize:
+    dependency: transitive
+    description:
+      name: angel3_serialize
+      sha256: "83fe50a347c130618b560f0c907ec71fd47c9f65990eaedcdbc57b846fdc21d8"
+      url: "https://pub.dev"
+    source: hosted
+    version: "8.4.0"
   ansi_styles:
     dependency: transitive
     description:
@@ -289,6 +305,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0+8.4.0"
+  dart_frog:
+    dependency: transitive
+    description:
+      name: dart_frog
+      sha256: "4ab2323ad74f935f5f76cb2de7e699d0319245e8029753878b0ddc35984f9cfe"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.6"
+  dart_jsonwebtoken:
+    dependency: transitive
+    description:
+      name: dart_jsonwebtoken
+      sha256: ad84e60181696513d04d5f2078e0bbc20365b911f46f647797317414bdc88fbe
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.4.1"
   dart_style:
     dependency: transitive
     description:
@@ -421,6 +453,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.0"
+  functions_client:
+    dependency: transitive
+    description:
+      name: functions_client
+      sha256: e9685e9ab852a8b8e0579c867f6c9155da27317b294b3df796a536b8b8e0d253
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.4"
   glob:
     dependency: transitive
     description:
@@ -437,6 +477,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "17.3.0"
+  gotrue:
+    dependency: transitive
+    description:
+      name: gotrue
+      sha256: "360bba9606e58d5acc59a033ab64ae3cf571a6868f7a7267cb8e9a204b7bf1b2"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.26.0"
+  graphql_parser2:
+    dependency: transitive
+    description:
+      name: graphql_parser2
+      sha256: "9bc9b1291a93e40290868f1d330e5ef957f264db476abeb10b075aa55a739b63"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
+  graphql_schema2:
+    dependency: transitive
+    description:
+      name: graphql_schema2
+      sha256: "46a31dce70a481a14264a643ce6f3959925104b20cf929b439eae7fcf2c288fb"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
+  graphql_server2:
+    dependency: transitive
+    description:
+      name: graphql_server2
+      sha256: "37e670d48fe96fedb377b00c3e4bd27db54c400032b5232135886c7f795ccbbd"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   graphs:
     dependency: transitive
     description:
@@ -445,6 +517,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.3.2"
+  hotreloader:
+    dependency: transitive
+    description:
+      name: hotreloader
+      sha256: "66871df468fc24eee81f1a0a7cb98acc104716f9b7376d355437b48d633c4ebf"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.4.0"
   http:
     dependency: transitive
     description:
@@ -453,6 +533,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.6.0"
+  http_methods:
+    dependency: transitive
+    description:
+      name: http_methods
+      sha256: "6bccce8f1ec7b5d701e7921dca35e202d425b57e317ba1a37f2638590e29e566"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.1"
   http_multi_server:
     dependency: transitive
     description:
@@ -509,6 +597,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.11.2"
+  jwt_decode:
+    dependency: transitive
+    description:
+      name: jwt_decode
+      sha256: d2e9f68c052b2225130977429d30f187aa1981d789c76ad104a32243cfdebfbb
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.1"
   leak_tracker:
     dependency: transitive
     description:
@@ -585,10 +681,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -693,6 +789,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: transitive
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   pool:
     dependency: transitive
     description:
@@ -709,6 +813,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "6.5.0"
+  postgrest:
+    dependency: transitive
+    description:
+      name: postgrest
+      sha256: "10e3f195e131eec944fa872644aed89b33b5be998f3fc77c87325db3927bc646"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.8.0"
   process:
     dependency: transitive
     description:
@@ -765,6 +877,38 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.0"
+  quiver:
+    dependency: transitive
+    description:
+      name: quiver
+      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.2.2"
+  realtime_client:
+    dependency: transitive
+    description:
+      name: realtime_client
+      sha256: "0cfbe0047e2591eba348938e9b4e620d5b1a8df6c374757e8eb8645252b8387f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.11.0"
+  recase:
+    dependency: transitive
+    description:
+      name: recase
+      sha256: e4eb4ec2dcdee52dcf99cb4ceabaffc631d7424ee55e56f280bc039737f89213
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.1.0"
+  retry:
+    dependency: transitive
+    description:
+      name: retry
+      sha256: "822e118d5b3aafed083109c72d5f484c6dc66707885e07c0fbcb8b986bba7efc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   riverpod:
     dependency: transitive
     description:
@@ -861,6 +1005,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.2"
+  shelf_hotreload:
+    dependency: transitive
+    description:
+      name: shelf_hotreload
+      sha256: "449f68ce2d087a030c2bfbb40e6925c63fac3dcb502a67388a7139ce72102e7a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.6.0"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -946,6 +1098,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.0"
+  storage_client:
+    dependency: transitive
+    description:
+      name: storage_client
+      sha256: "221263cfbe0c01575b7d7fe7543e44abff380eb4d38d936372844a1caa85ba12"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.6.0"
   stream_channel:
     dependency: transitive
     description:
@@ -970,6 +1130,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.4.1"
+  supabase:
+    dependency: transitive
+    description:
+      name: supabase
+      sha256: "3879996256325fcc9abb03b62b12c07e4eaae2e008e1bf043cc1525184159a43"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.14.0"
   term_glyph:
     dependency: transitive
     description:
@@ -982,26 +1150,34 @@ packages:
     dependency: transitive
     description:
       name: test
-      sha256: "8d9ceddbab833f180fbefed08afa76d7c03513dfdba87ffcec2718b02bbcbf20"
+      sha256: "280d6d890011ca966ad08df7e8a4ddfab0fb3aa49f96ed6de56e3521347a9ae7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.31.0"
+    version: "1.30.0"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "8161c84903fd860b26bfdefb7963b3f0b68fee7adea0f59ef805ecca346f0c7a"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.10"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "1991d4cfe85d5043241acac92962c3977c8d2f2add1ee73130c7b286417d1d34"
+      sha256: "0381bd1585d1a924763c308100f2138205252fb90c9d4eeaf28489ee65ccde51"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.17"
+    version: "0.6.16"
+  tuple:
+    dependency: transitive
+    description:
+      name: tuple
+      sha256: a97ce2013f240b2f3807bcbaf218765b6f301c3eff91092bcfa23a039e7dd151
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.0.2"
   typed_data:
     dependency: transitive
     description:
@@ -1122,6 +1298,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.4"
+  yet_another_json_isolate:
+    dependency: transitive
+    description:
+      name: yet_another_json_isolate
+      sha256: eaa26beb5990b25a49d942374fd5a0c5aa67a837e03b14b4c26134aaa1ed01a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
 sdks:
   dart: ">=3.11.0 <4.0.0"
   flutter: ">=3.38.0"

--- a/supabase/migrations/20260707140000_geo_search.sql
+++ b/supabase/migrations/20260707140000_geo_search.sql
@@ -1,0 +1,239 @@
+-- BE-301 · Nearby hotels function
+-- BE-302 · Room availability query
+-- BE-304 · Recommended hotels function
+--
+-- Geolocation search & recommendations (EPIC-03). Three read-only functions the
+-- backend GraphQL layer calls; all are SECURITY DEFINER with a pinned
+-- search_path so they can compute availability across every reservation (a guest
+-- cannot see other guests' holds under RLS) while only ever returning public
+-- catalogue data (hotels/rooms) — never another guest's reservation rows.
+
+-- ---------------------------------------------------------------------------
+-- BE-302 · hold_expires_at
+-- ---------------------------------------------------------------------------
+-- We use the free-tier, query-time expiry model (BE-403): a hold is not cleaned
+-- up by a background job, so "available now" must ignore holds whose expiry has
+-- already passed. Nullable: only active holds/bookings carry an expiry.
+alter table public.reservations
+  add column hold_expires_at timestamptz;
+
+comment on column public.reservations.hold_expires_at is
+  'When a held/confirmed reservation stops blocking the room. A row whose '
+  'hold_expires_at is in the past no longer counts against availability, even '
+  'if it is still status=held (query-time expiry, BE-403).';
+
+-- Availability lookups scan reservations by room + status + expiry.
+create index reservations_room_active_idx
+  on public.reservations (room_id, status, hold_expires_at);
+
+-- ---------------------------------------------------------------------------
+-- Tunable constants
+-- ---------------------------------------------------------------------------
+-- The trailing popularity window (BE-304). A single documented definition so it
+-- can be tuned in one place later.
+create or replace function public.recommendation_window_days()
+returns integer
+language sql
+immutable
+as $$
+  select 30;
+$$;
+
+comment on function public.recommendation_window_days() is
+  'Trailing window (days) over which confirmed reservations count toward the '
+  'recommended-hotels popularity signal (BE-304). Tune here.';
+
+-- ---------------------------------------------------------------------------
+-- BE-302 · room availability
+-- ---------------------------------------------------------------------------
+
+-- Is a single room bookable right now? Reusable by the search functions below.
+-- available_now == room flagged available AND no held/confirmed reservation with
+-- an unexpired hold blocks it.
+create or replace function public.is_room_available_now(p_room_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public, extensions
+as $$
+  select r.is_available
+     and not exists (
+       select 1
+       from public.reservations res
+       where res.room_id = r.id
+         and res.status in ('held', 'confirmed')
+         and res.hold_expires_at is not null
+         and res.hold_expires_at > now()
+     )
+  from public.rooms r
+  where r.id = p_room_id;
+$$;
+
+-- Every room (optionally scoped to one hotel) with a computed `available_now`.
+-- Consumed via the backend data client — no availability SQL lives in UI code.
+create or replace function public.rooms_with_availability(p_hotel_id uuid default null)
+returns table (
+  id              uuid,
+  hotel_id        uuid,
+  name            text,
+  room_type       text,
+  capacity        integer,
+  price_per_night numeric,
+  is_available    boolean,
+  available_now   boolean
+)
+language sql
+stable
+security definer
+set search_path = public, extensions
+as $$
+  select
+    r.id,
+    r.hotel_id,
+    r.name,
+    r.room_type,
+    r.capacity,
+    r.price_per_night,
+    r.is_available,
+    r.is_available
+      and not exists (
+        select 1
+        from public.reservations res
+        where res.room_id = r.id
+          and res.status in ('held', 'confirmed')
+          and res.hold_expires_at is not null
+          and res.hold_expires_at > now()
+      ) as available_now
+  from public.rooms r
+  where p_hotel_id is null or r.hotel_id = p_hotel_id
+  order by r.hotel_id, r.name;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- BE-301 · nearby hotels
+-- ---------------------------------------------------------------------------
+
+-- Hotels within `radius_km` of (lat, lng), nearest-first, each with its great-
+-- circle distance in km. ST_DWithin filters the radius (metres, via geography so
+-- it is accurate near the poles/antimeridian); ST_Distance drives the ordering.
+-- Returns zero rows (an empty list, not an error) when nothing is in range.
+create or replace function public.nearby_hotels(
+  lat       double precision,
+  lng       double precision,
+  radius_km double precision
+)
+returns table (
+  id          uuid,
+  name        text,
+  description text,
+  address     text,
+  city        text,
+  country     text,
+  latitude    double precision,
+  longitude   double precision,
+  distance_km double precision
+)
+language sql
+stable
+security definer
+set search_path = public, extensions
+as $$
+  with origin as (
+    select st_setsrid(st_makepoint(lng, lat), 4326)::geography as g
+  )
+  select
+    h.id,
+    h.name,
+    h.description,
+    h.address,
+    h.city,
+    h.country,
+    st_y(h.location::geometry) as latitude,
+    st_x(h.location::geometry) as longitude,
+    st_distance(h.location::geography, origin.g) / 1000.0 as distance_km
+  from public.hotels h, origin
+  where h.location is not null
+    and st_dwithin(h.location::geography, origin.g, radius_km * 1000.0)
+  order by st_distance(h.location::geography, origin.g);
+$$;
+
+-- ---------------------------------------------------------------------------
+-- BE-304 · recommended hotels
+-- ---------------------------------------------------------------------------
+
+-- Popular-yet-nearby hotels: rank in-radius hotels by their count of `confirmed`
+-- reservations booked in the trailing window (rejected/expired/cancelled never
+-- count), breaking ties by proximity (nearest-first within equal rank).
+--
+-- Cold-start: at launch there are no confirmed reservations, so every hotel's
+-- popularity is 0. In that case proximity must carry the experience, so we fall
+-- back to the nearby_hotels result filtered to hotels that have at least one
+-- available-now room — never empty (when hotels exist in range), never
+-- arbitrarily ordered.
+--
+-- Future extension: a "most rated" signal is intentionally out of scope until
+-- the Phase 2 ratings feature exists; it would blend in as an additional term.
+create or replace function public.recommended_hotels(
+  lat       double precision,
+  lng       double precision,
+  radius_km double precision
+)
+returns table (
+  id          uuid,
+  name        text,
+  description text,
+  address     text,
+  city        text,
+  country     text,
+  latitude    double precision,
+  longitude   double precision,
+  distance_km double precision,
+  popularity  bigint
+)
+language sql
+stable
+security definer
+set search_path = public, extensions
+as $$
+  with base as (
+    select * from public.nearby_hotels(lat, lng, radius_km)
+  ),
+  ranked as (
+    select
+      b.*,
+      (
+        select count(*)
+        from public.reservations res
+        where res.hotel_id = b.id
+          and res.status = 'confirmed'
+          and res.created_at >= now()
+            - make_interval(days => public.recommendation_window_days())
+      ) as popularity
+    from base b
+  ),
+  has_signal as (
+    select coalesce(max(popularity), 0) > 0 as any_popular from ranked
+  )
+  select
+    r.id, r.name, r.description, r.address, r.city, r.country,
+    r.latitude, r.longitude, r.distance_km, r.popularity
+  from ranked r, has_signal
+  where has_signal.any_popular
+     -- Cold-start branch: keep only hotels with an available-now room.
+     or exists (
+       select 1
+       from public.rooms rm
+       where rm.hotel_id = r.id
+         and public.is_room_available_now(rm.id)
+     )
+  order by r.popularity desc, r.distance_km asc;
+$$;
+
+-- ---------------------------------------------------------------------------
+-- Execute grants (callable by authenticated app sessions / the backend)
+-- ---------------------------------------------------------------------------
+grant execute on function public.is_room_available_now(uuid)                         to authenticated;
+grant execute on function public.rooms_with_availability(uuid)                       to authenticated;
+grant execute on function public.nearby_hotels(double precision, double precision, double precision)      to authenticated;
+grant execute on function public.recommended_hotels(double precision, double precision, double precision) to authenticated;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -176,19 +176,21 @@ on conflict (id) do update set
 -- Reservations (one confirmed booking for the test guest at the Lima hotel)
 -- ---------------------------------------------------------------------------
 
-insert into public.reservations (id, hotel_id, room_id, guest_id, status, check_in, check_out)
+insert into public.reservations (id, hotel_id, room_id, guest_id, status, check_in, check_out, hold_expires_at)
 values
   (
     '30000000-0000-0000-0000-000000000001',
     '10000000-0000-0000-0000-000000000001',
     '20000000-0000-0000-0000-000000000002',
     '00000000-0000-0000-0000-000000000001',
-    'confirmed', date '2026-08-01', date '2026-08-05'
+    -- Confirmed booking that blocks the room through check-out (BE-302).
+    'confirmed', date '2026-08-01', date '2026-08-05', timestamptz '2026-08-05 00:00:00+00'
   )
 on conflict (id) do update set
-  hotel_id  = excluded.hotel_id,
-  room_id   = excluded.room_id,
-  guest_id  = excluded.guest_id,
-  status    = excluded.status,
-  check_in  = excluded.check_in,
-  check_out = excluded.check_out;
+  hotel_id        = excluded.hotel_id,
+  room_id         = excluded.room_id,
+  guest_id        = excluded.guest_id,
+  status          = excluded.status,
+  check_in        = excluded.check_in,
+  check_out       = excluded.check_out,
+  hold_expires_at = excluded.hold_expires_at;

--- a/supabase/tests/geo_search_test.sql
+++ b/supabase/tests/geo_search_test.sql
@@ -1,0 +1,185 @@
+-- BE-301 / BE-302 / BE-304 · Geolocation search & recommendations.
+--
+-- Run with: `supabase test db`. These exercise the three SQL functions'
+-- behaviour directly (they are SECURITY DEFINER, so no role juggling is needed);
+-- RLS itself is covered by rls_test.sql.
+--
+-- Seeded coordinates used below (lon, lat):
+--   Lima   10000000-...0001  (-77.0428, -12.1219)
+--   Bogota 10000000-...0003  (-74.0546,   4.6663)
+--   NY     10000000-...0005  (-73.9840,  40.7536)
+--   Miami  10000000-...0006  (-80.1918,  25.7617)
+
+begin;
+
+select plan(15);
+
+-- Clean slate for reservation-dependent assertions; rolled back at the end.
+delete from public.reservations;
+
+-- ---------------------------------------------------------------------------
+-- Tunable window constant (BE-304)
+-- ---------------------------------------------------------------------------
+select is(
+  public.recommendation_window_days(), 30,
+  'recommendation window is the documented 30-day constant'
+);
+
+-- ---------------------------------------------------------------------------
+-- BE-301 · nearby_hotels
+-- ---------------------------------------------------------------------------
+
+-- Nearest-first ordering: the closest hotel to a point in Lima is the Lima one.
+select is(
+  (select city from public.nearby_hotels(-12.11, -77.03, 20000) limit 1),
+  'Lima',
+  'nearby_hotels returns the nearest hotel first'
+);
+
+-- Distance is computed in kilometres and is small for the ~2 km-away Lima hotel.
+select cmp_ok(
+  (select distance_km from public.nearby_hotels(-12.11, -77.03, 20000)
+     where city = 'Lima'),
+  '<', 5.0::double precision,
+  'nearby_hotels reports distance in km (Lima ~2 km away)'
+);
+
+-- Radius filter (ST_DWithin): a 100 km radius around Lima yields only Lima.
+select is(
+  (select count(*)::int from public.nearby_hotels(-12.11, -77.03, 100)),
+  1,
+  'nearby_hotels radius filter excludes out-of-range hotels'
+);
+
+-- No hotels in range → empty list, not an error.
+select is(
+  (select count(*)::int from public.nearby_hotels(0, 0, 10)),
+  0,
+  'nearby_hotels returns an empty set when nothing is in radius'
+);
+
+-- Ordering is strictly non-decreasing by distance.
+select is(
+  (select bool_and(distance_km >= lag_km) from (
+     select distance_km, lag(distance_km) over (order by distance_km) as lag_km
+     from public.nearby_hotels(-12.11, -77.03, 20000)
+   ) t where lag_km is not null),
+  true,
+  'nearby_hotels rows are ordered nearest-first'
+);
+
+-- ---------------------------------------------------------------------------
+-- BE-302 · room availability
+-- ---------------------------------------------------------------------------
+-- Bogota room 200...0005 is flagged available and has no reservations yet.
+
+-- An EXPIRED hold does not block: the room still reads available even though the
+-- reservation row is status=held (the core BE-302 acceptance criterion).
+insert into public.reservations (id, hotel_id, room_id, guest_id, status, check_in, check_out, hold_expires_at)
+values ('30000000-0000-0000-0000-0000000000e1',
+        '10000000-0000-0000-0000-000000000003',
+        '20000000-0000-0000-0000-000000000005',
+        '00000000-0000-0000-0000-000000000001',
+        'held', date '2026-08-01', date '2026-08-02', now() - interval '1 hour');
+
+select is(
+  public.is_room_available_now('20000000-0000-0000-0000-000000000005'),
+  true,
+  'a room whose only hold is EXPIRED reads as available'
+);
+
+-- Same room, now with an ACTIVE (future) hold → unavailable.
+update public.reservations set hold_expires_at = now() + interval '1 hour'
+ where id = '30000000-0000-0000-0000-0000000000e1';
+
+select is(
+  public.is_room_available_now('20000000-0000-0000-0000-000000000005'),
+  false,
+  'a room with an active unexpired hold reads as unavailable'
+);
+
+-- A room flagged is_available = false is never available_now.
+select is(
+  (select available_now from public.rooms_with_availability('10000000-0000-0000-0000-000000000001')
+     where id = '20000000-0000-0000-0000-000000000002'),
+  false,
+  'a room flagged unavailable is never available_now'
+);
+
+-- rooms_with_availability reports available_now = true for a truly free room.
+select is(
+  (select available_now from public.rooms_with_availability('10000000-0000-0000-0000-000000000001')
+     where id = '20000000-0000-0000-0000-000000000001'),
+  true,
+  'rooms_with_availability reports a free room as available_now'
+);
+
+delete from public.reservations;
+
+-- ---------------------------------------------------------------------------
+-- BE-304 · recommended_hotels
+-- ---------------------------------------------------------------------------
+
+-- Two confirmed bookings at Bogota, one at Lima, all within the window.
+insert into public.reservations (hotel_id, room_id, guest_id, status, check_in, check_out, hold_expires_at)
+values
+  ('10000000-0000-0000-0000-000000000003', '20000000-0000-0000-0000-000000000005',
+   '00000000-0000-0000-0000-000000000001', 'confirmed', date '2026-08-01', date '2026-08-03', now() + interval '10 days'),
+  ('10000000-0000-0000-0000-000000000003', '20000000-0000-0000-0000-000000000005',
+   '00000000-0000-0000-0000-000000000001', 'confirmed', date '2026-08-04', date '2026-08-06', now() + interval '10 days'),
+  ('10000000-0000-0000-0000-000000000001', '20000000-0000-0000-0000-000000000001',
+   '00000000-0000-0000-0000-000000000001', 'confirmed', date '2026-08-01', date '2026-08-03', now() + interval '10 days');
+
+-- Popularity ranking: Bogota (2 confirmed) outranks Lima (1) regardless of the
+-- fact that Lima is nearer the query point.
+select is(
+  (select city from public.recommended_hotels(-12.11, -77.03, 20000) limit 1),
+  'Bogota',
+  'recommended_hotels ranks the more-booked hotel first, over a nearer one'
+);
+
+select is(
+  (select popularity from public.recommended_hotels(-12.11, -77.03, 20000)
+     where city = 'Bogota'),
+  2::bigint,
+  'recommended_hotels counts confirmed reservations in the window'
+);
+
+-- Non-confirmed statuses and out-of-window bookings do NOT count.
+insert into public.reservations (hotel_id, room_id, guest_id, status, check_in, check_out, created_at)
+values
+  ('10000000-0000-0000-0000-000000000006', '20000000-0000-0000-0000-000000000009',
+   '00000000-0000-0000-0000-000000000001', 'cancelled', date '2026-08-01', date '2026-08-02', now()),
+  ('10000000-0000-0000-0000-000000000006', '20000000-0000-0000-0000-000000000009',
+   '00000000-0000-0000-0000-000000000001', 'rejected',  date '2026-08-01', date '2026-08-02', now()),
+  ('10000000-0000-0000-0000-000000000006', '20000000-0000-0000-0000-000000000009',
+   '00000000-0000-0000-0000-000000000001', 'expired',   date '2026-08-01', date '2026-08-02', now()),
+  ('10000000-0000-0000-0000-000000000006', '20000000-0000-0000-0000-000000000009',
+   '00000000-0000-0000-0000-000000000001', 'confirmed', date '2026-08-01', date '2026-08-02', now() - interval '60 days');
+
+select is(
+  (select popularity from public.recommended_hotels(25.76, -80.19, 20000)
+     where city = 'Miami'),
+  0::bigint,
+  'rejected/expired/cancelled and out-of-window bookings do not count'
+);
+
+-- Cold-start: with zero qualifying reservations, recommended falls back to
+-- nearby filtered to available-now — non-empty and nearest-first.
+delete from public.reservations;
+
+select cmp_ok(
+  (select count(*)::int from public.recommended_hotels(-12.11, -77.03, 20000)),
+  '>', 0,
+  'cold-start recommended_hotels is never empty when hotels are in range'
+);
+
+select is(
+  (select city from public.recommended_hotels(-12.11, -77.03, 20000) limit 1),
+  'Lima',
+  'cold-start recommended_hotels falls back to nearest-first'
+);
+
+select * from finish();
+
+rollback;


### PR DESCRIPTION
## Summary

Implements the **EPIC-03 · Geolocation search & recommendations** backend (BE-301/302/304) as SQL functions, plus a Dart Frog GraphQL server that exposes them. The Flutter apps never touch Supabase directly — all access goes through the GraphQL layer's data client.

### SQL (Supabase / PostGIS) — `..._geo_search.sql`
- **BE-301 (#163) `nearby_hotels(lat, lng, radius_km)`** — `ST_DWithin` radius filter, `ST_Distance` ordering, `distance_km` per row, nearest-first. A point with nothing in range returns an empty set, not an error.
- **BE-302 (#164) room availability** — adds `reservations.hold_expires_at` and `rooms_with_availability()` / `is_room_available_now()` computing `available_now` = room flagged available **and** no `held`/`confirmed` reservation with `hold_expires_at > now()`. An expired hold no longer blocks the room even though the row still says `held` (query-time expiry, BE-403).
- **BE-304 (#166) `recommended_hotels(lat, lng, radius_km)`** — ranks in-radius hotels by `confirmed` reservations in the trailing `recommendation_window_days()` (a single documented **30-day** constant), ties broken by proximity. Rejected/expired/cancelled and out-of-window bookings never count. **Cold-start** (all zero) falls back to `nearby_hotels` filtered to available-now — never empty, never arbitrary order. "Most rated" is noted as a Phase-2 extension.
- All three are `SECURITY DEFINER` with a pinned `search_path` (compute availability across all reservations, return only public catalogue rows).

### GraphQL backend (Dart Frog)
- `Hotel` / `Room` domain entities in `hotelyn_domain`.
- `HotelDataClient` — Supabase RPC wrapper, the single seam to Supabase.
- Schema + resolvers (`graphql_schema2` / `graphql_server2`) for `nearbyHotels`, `recommendedHotels`, `roomsAvailability`, served at `POST /graphql` with JSON error envelopes and required non-null `Float` args.

### Performance (BE-301 AC)
Measured on the local stack with **100 hotels** (98 in a 200 km radius), 200 runs after warm-up:

| p50 | p95 | p99 | max |
| --- | --- | --- | --- |
| 0.24 ms | **0.27 ms** | 0.34 ms | 0.63 ms |

Well under the 300 ms budget; the query uses the `geography` GiST index (verified via `EXPLAIN`).

### Incidental fix
Pins `test` to `1.30.0` across packages to match the Flutter SDK's bundled `test_api` (0.7.10) — repairs the workspace dependency-resolution break introduced by the `test` bump in #225 (without it, `pub get`/analyze/test fail workspace-wide).

Closes #163
Closes #164
Closes #166

## Test plan

- [x] `supabase db reset` applies all migrations + seed cleanly from scratch
- [x] `supabase test db` — geo-search pgTAP suite (15) + RLS suite (14) pass
- [x] `nearby_hotels`: nearest-first ordering, `distance_km` in km, radius filter, empty-radius → empty set
- [x] availability: expired hold reads available; active hold reads unavailable; `is_available=false` never `available_now`
- [x] `recommended_hotels`: popularity ranking (more-booked over nearer), non-confirmed/out-of-window excluded, cold-start nearest-first fallback
- [x] Composite FK / SECURITY DEFINER behaviour unchanged (RLS suite still green)
- [x] `melos run analyze --no-select` — all packages pass (`--fatal-infos`)
- [x] `melos run test --no-select` — green (backend: row mappers, schema/resolvers, route handler incl. 405 / 400 malformed-JSON / 400 bad-variables / 200 / 400 malformed-query; domain: entity equality)
- [x] p95 latency recorded above

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added geolocation search and hotel recommendations, plus room availability lookup.
  * Added a GraphQL endpoint for nearby hotels, recommended hotels, and room availability.
  * Expanded the public API docs with local run steps and request examples.

* **Bug Fixes**
  * Improved availability handling so expired holds no longer block rooms.
  * Added support for both direct search results and fallback recommendations when demand data is limited.

* **Tests**
  * Added automated coverage for search, availability, GraphQL behavior, and data mapping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->