### PR TITLE
docs(api-client): document full REST method surface (BE-801)

### DIFF
--- a/packages/hotelyn_api_client/README.md
+++ b/packages/hotelyn_api_client/README.md
@@ -25,9 +25,18 @@ called before every request to obtain the Supabase JWT, which is attached as a
 `Bearer` token in the `Authorization` header; return `null` when signed out.
 
 Non-2xx responses throw an `ApiException` carrying the HTTP `statusCode` and the
-server-provided message when one is present.
+server-provided message when one is present. Two typed subtypes let callers
+react to specific failures without string-matching:
+
+- `RoomAlreadyHeldException` — a `409` from `createReservationHold` (the room was
+  grabbed first). Still an `ApiException`, so a generic `catch` handles it too.
+- `AuthApiException` — an auth failure carrying the server's stable `code`
+  (e.g. `otp_expired`, `invalid_credentials`) and, for rate limits,
+  `retryAfterSeconds`.
 
 ## Methods
+
+### Discovery
 
 | Method | Endpoint |
 | --- | --- |
@@ -35,8 +44,33 @@ server-provided message when one is present.
 | `getRecommendedHotels({lat, lng, radiusKm})` | `GET /hotels/recommended` |
 | `getRooms({hotelId})` | `GET /hotels/{id}/rooms` |
 
-Auth, reservation, and messaging methods are added as their endpoints land
-(see issues FE-2002, FE-2004).
+### Reservations
+
+| Method | Endpoint |
+| --- | --- |
+| `createReservationHold({hotelId, roomId, checkIn, checkOut})` | `POST /hotels/{id}/holds` |
+| `confirmReservation({reservationId})` | `POST /reservations/{id}/confirm` |
+| `rejectReservation({reservationId})` | `POST /reservations/{id}/reject` |
+
+### Staff inventory
+
+| Method | Endpoint |
+| --- | --- |
+| `getStaffRooms()` | `GET /staff/rooms` |
+| `setRoomAvailability({roomId, isAvailable})` | `PATCH /staff/rooms/{id}/availability` |
+
+`getStaffRooms` is scoped to the acting staff member's hotel via the caller's
+token — there is no hotel parameter.
+
+### Auth
+
+| Method | Endpoint |
+| --- | --- |
+| `requestEmailOtp({email})` | `POST /auth/otp/request` |
+| `verifyEmailOtp({email, token})` | `POST /auth/otp/verify` |
+| `signInWithPassword({email, password})` | `POST /auth/login` |
+
+Call `close()` to release the underlying HTTP client when the client is disposed.
 
 ## Testing
 


### PR DESCRIPTION
## Summary

Issue #181 (BE-801) asks for the `hotelyn_api_client` package scaffold: a valid `pubspec.yaml`, workspace/melos listing, `http` + `hotelyn_domain` deps, a `lib/src/` structure with a barrel export, `json_serializable`-based decoding (no hand-written mappers), and a `README.md` documenting the base-URL config and available methods.

Reviewing the current state, everything in that checklist already landed as a side-effect of the REST migration and feature PRs (#230–#234):

- ✅ `packages/hotelyn_api_client/` with a valid `pubspec.yaml` (`http`, `hotelyn_domain`)
- ✅ Listed in the root workspace `pubspec.yaml` (melos config is embedded there — there is no separate `melos.yaml`)
- ✅ `lib/src/` split into client + exceptions with a `hotelyn_api_client.dart` barrel
- ✅ Models decoded via `Hotel.fromJson` / `Room.fromJson` / etc. — no hand-written mappers

The **one** remaining gap against the acceptance criteria was the README: it still documented only the three discovery methods and described auth/reservation methods as "added as their endpoints land," even though they had already landed. This PR closes that gap:

- Group the full method surface into endpoint tables — Discovery, Reservations, Staff inventory, Auth.
- Document the typed exception subtypes (`RoomAlreadyHeldException`, `AuthApiException`) and their fields.
- Note the token-scoped nature of `getStaffRooms` and the `close()` lifecycle method.

Documentation-only change; no code or behavior touched.

Closes #181

## Test plan

- [x] `dart pub get` resolves at the workspace root
- [x] `flutter analyze --fatal-infos` on the package — no issues
- [x] `flutter test` on the package — all 21 tests pass
- [x] `coderabbit review` — no findings
- [x] README method tables verified against the actual `HotelynApiClient` public API

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded API client documentation with detailed endpoint references for discovery, reservations, staff inventory, and authentication.
  * Documented typed errors for room-hold conflicts and authentication failures, including rate-limit retry details.
  * Added guidance to close the client when it is no longer needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->