### PR TITLE
feat(domain): User entity + reservation payment-audit guard (BE-802)

### DIFF
--- a/packages/hotelyn_domain/lib/hotelyn_domain.dart
+++ b/packages/hotelyn_domain/lib/hotelyn_domain.dart
@@ -6,3 +6,4 @@ export 'src/hotel.dart';
 export 'src/reservation.dart';
 export 'src/room.dart';
 export 'src/staff_room.dart';
+export 'src/user.dart';

--- a/packages/hotelyn_domain/lib/src/reservation.dart
+++ b/packages/hotelyn_domain/lib/src/reservation.dart
@@ -28,7 +28,7 @@ enum ReservationStatus {
 /// (`room_id`, `hold_expires_at`, `confirmation_code`, …).
 @JsonSerializable(fieldRename: FieldRename.snake)
 class Reservation extends Equatable {
-  const Reservation({
+  Reservation({
     required this.id,
     required this.hotelId,
     required this.roomId,
@@ -40,7 +40,26 @@ class Reservation extends Equatable {
     this.confirmationCode,
     this.paidBy,
     this.paidAt,
-  });
+  }) {
+    // The manual-payment audit fields are written together by
+    // mark_reservation_paid (BE-702): a payment stamps *both* who took it and
+    // when. Neither alone is a coherent record, so reject a row that carries
+    // one without the other — it would let audit code read a payment that has
+    // no actor, or an actor with no timestamp.
+    //
+    // A `confirmed` reservation may legitimately have neither: staff
+    // confirm_reservation (BE-503) is a distinct action from taking payment and
+    // does not set paid_at.
+    //
+    // This is an unconditional throw, not an `assert`: the entity decodes
+    // backend JSON and the guard must hold in release builds too, where asserts
+    // are stripped.
+    if ((paidBy == null) != (paidAt == null)) {
+      throw ArgumentError(
+        'paidBy and paidAt must be set together (both or neither)',
+      );
+    }
+  }
 
   /// Decodes a `Reservation` from a REST/RPC JSON row.
   factory Reservation.fromJson(Map<String, dynamic> json) =>

--- a/packages/hotelyn_domain/lib/src/user.dart
+++ b/packages/hotelyn_domain/lib/src/user.dart
@@ -1,0 +1,80 @@
+import 'package:equatable/equatable.dart';
+import 'package:json_annotation/json_annotation.dart';
+
+part 'user.g.dart';
+
+/// The app-specific role attached to a user's profile, mirroring the Postgres
+/// `user_role` enum.
+///
+/// Identity lives in Supabase's `auth.users`; this role (and hotel ownership)
+/// lives on the linked `profiles` row (BE-101). A [hotelStaff] user is expected
+/// to carry a [User.hotelId]; [guest] and [admin] never do.
+enum UserRole {
+  @JsonValue('guest')
+  guest,
+  @JsonValue('hotel_staff')
+  hotelStaff,
+  @JsonValue('admin')
+  admin,
+}
+
+/// A user of Hotelyn — the app-side view of a `profiles` row (BE-101).
+///
+/// Models the *problem* (who this person is and what they can do), not the row:
+/// [role] is an enum and construction rejects a [UserRole.hotelStaff] with no
+/// [hotelId]. Identity attributes that live on `auth.users` (email, phone) are
+/// deliberately not part of this entity.
+///
+/// JSON keys are snake_case to match the REST API / Postgres row shape
+/// (`full_name`, `hotel_id`, …).
+@JsonSerializable(fieldRename: FieldRename.snake)
+class User extends Equatable {
+  User({
+    required this.id,
+    required this.role,
+    this.fullName,
+    this.hotelId,
+  }) {
+    // A hotel_staff profile is scoped to exactly one hotel; guests and admins
+    // never carry a hotel (BE-101 `profiles.hotel_id`). Enforce both
+    // directions so a decoded row can neither let a staff member act with no
+    // hotel scope nor attach a stray hotel to a guest/admin.
+    //
+    // This is an unconditional throw, not an `assert`: the entity decodes
+    // backend JSON and the guard must hold in release builds too, where asserts
+    // are stripped.
+    final hasHotel = hotelId != null;
+    if ((role == UserRole.hotelStaff) != hasHotel) {
+      throw ArgumentError(
+        'hotelId must be set for hotelStaff users and null otherwise',
+      );
+    }
+  }
+
+  /// Decodes a `User` from a REST/RPC JSON row.
+  factory User.fromJson(Map<String, dynamic> json) => _$UserFromJson(json);
+
+  /// The user's id — the same uuid as the linked `auth.users` row.
+  final String id;
+
+  /// The app-specific role controlling what this user can do.
+  final UserRole role;
+
+  /// Display name, when the profile carries one. `null` if unset.
+  final String? fullName;
+
+  /// The hotel this user works for. Set for [UserRole.hotelStaff]; `null` for
+  /// guests and admins.
+  final String? hotelId;
+
+  /// Encodes this `User` to a snake_case JSON map.
+  Map<String, dynamic> toJson() => _$UserToJson(this);
+
+  @override
+  List<Object?> get props => [
+        id,
+        role,
+        fullName,
+        hotelId,
+      ];
+}

--- a/packages/hotelyn_domain/lib/src/user.g.dart
+++ b/packages/hotelyn_domain/lib/src/user.g.dart
@@ -1,0 +1,27 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'user.dart';
+
+// **************************************************************************
+// JsonSerializableGenerator
+// **************************************************************************
+
+User _$UserFromJson(Map<String, dynamic> json) => User(
+      id: json['id'] as String,
+      role: $enumDecode(_$UserRoleEnumMap, json['role']),
+      fullName: json['full_name'] as String?,
+      hotelId: json['hotel_id'] as String?,
+    );
+
+Map<String, dynamic> _$UserToJson(User instance) => <String, dynamic>{
+      'id': instance.id,
+      'role': _$UserRoleEnumMap[instance.role]!,
+      'full_name': instance.fullName,
+      'hotel_id': instance.hotelId,
+    };
+
+const _$UserRoleEnumMap = {
+  UserRole.guest: 'guest',
+  UserRole.hotelStaff: 'hotel_staff',
+  UserRole.admin: 'admin',
+};

--- a/packages/hotelyn_domain/test/reservation_test.dart
+++ b/packages/hotelyn_domain/test/reservation_test.dart
@@ -159,4 +159,75 @@ void main() {
       expect(a, equals(b));
     });
   });
+
+  group('Reservation payment-audit invariant', () {
+    // The manual-payment audit fields (paid_by/paid_at) are written together by
+    // mark_reservation_paid (BE-702); a row carrying one without the other is
+    // an incoherent payment record and is rejected at construction.
+    Map<String, dynamic> row({String? paidBy, String? paidAt}) => {
+          'id': 'res-1',
+          'hotel_id': 'h1',
+          'room_id': 'r1',
+          'guest_id': 'g1',
+          'status': 'confirmed',
+          'check_in': '2026-09-01',
+          'check_out': '2026-09-03',
+          if (paidBy != null) 'paid_by': paidBy,
+          if (paidAt != null) 'paid_at': paidAt,
+        };
+
+    test('rejects paid_by without paid_at (via fromJson)', () {
+      expect(
+        () => Reservation.fromJson(row(paidBy: 'staff-1')),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects paid_at without paid_by (via fromJson)', () {
+      expect(
+        () => Reservation.fromJson(row(paidAt: '2026-09-01T10:30:00Z')),
+        throwsArgumentError,
+      );
+    });
+
+    test('rejects a directly-constructed half-stamped payment', () {
+      // A runtime throw (not an assert), so it also fires in release builds.
+      expect(
+        () => Reservation(
+          id: 'res-1',
+          hotelId: 'h1',
+          roomId: 'r1',
+          guestId: 'g1',
+          status: ReservationStatus.confirmed,
+          checkIn: DateTime.utc(2026, 9),
+          checkOut: DateTime.utc(2026, 9, 3),
+          paidBy: 'staff-1',
+        ),
+        throwsArgumentError,
+      );
+    });
+
+    test('accepts a fully-stamped payment (both fields set)', () {
+      final reservation = Reservation.fromJson(
+        row(paidBy: 'staff-1', paidAt: '2026-09-01T10:30:00Z'),
+      );
+
+      expect(reservation.paidBy, 'staff-1');
+      expect(reservation.paidAt, DateTime.utc(2026, 9, 1, 10, 30));
+    });
+
+    test('accepts an unpaid reservation (neither field set)', () {
+      expect(() => Reservation.fromJson(row()), returnsNormally);
+    });
+
+    test('allows a confirmed reservation with no payment stamp (BE-503)', () {
+      // Staff confirm_reservation transitions a hold to confirmed without
+      // taking payment, so confirmed + no paid_by/paid_at is a valid state.
+      final reservation = Reservation.fromJson(row());
+
+      expect(reservation.status, ReservationStatus.confirmed);
+      expect(reservation.paidBy, isNull);
+      expect(reservation.paidAt, isNull);
+    });
+  });
 }

--- a/packages/hotelyn_domain/test/user_test.dart
+++ b/packages/hotelyn_domain/test/user_test.dart
@@ -1,0 +1,146 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:test/test.dart';
+
+// User is the app-side view of a `profiles` row (BE-101). These pin the
+// snake_case row shape, the user_role enum mapping, and the construction-time
+// invariant that a hotel_staff user is scoped to a hotel.
+void main() {
+  group('User', () {
+    test('supports value equality', () {
+      final a = User(id: 'u1', role: UserRole.guest, fullName: 'Ada');
+      final b = User(id: 'u1', role: UserRole.guest, fullName: 'Ada');
+      expect(a, equals(b));
+    });
+
+    test('differs when the role differs', () {
+      final guest = User(id: 'u1', role: UserRole.guest);
+      final admin = User(id: 'u1', role: UserRole.admin);
+      expect(guest, isNot(equals(admin)));
+    });
+
+    test('leaves fullName and hotelId null by default', () {
+      final user = User(id: 'u1', role: UserRole.guest);
+      expect(user.fullName, isNull);
+      expect(user.hotelId, isNull);
+    });
+
+    group('fromJson', () {
+      test('decodes a guest profile row', () {
+        final user = User.fromJson(const {
+          'id': 'u1',
+          'role': 'guest',
+          'full_name': 'Ada Lovelace',
+          'hotel_id': null,
+        });
+
+        expect(user.id, 'u1');
+        expect(user.role, UserRole.guest);
+        expect(user.fullName, 'Ada Lovelace');
+        expect(user.hotelId, isNull);
+      });
+
+      test('maps the hotel_staff role from its snake_case JSON value', () {
+        final user = User.fromJson(const {
+          'id': 'u2',
+          'role': 'hotel_staff',
+          'hotel_id': 'h1',
+        });
+
+        expect(user.role, UserRole.hotelStaff);
+        expect(user.hotelId, 'h1');
+      });
+
+      test('decodes each user_role enum value', () {
+        User withRole(String role, {String? hotelId}) => User.fromJson({
+              'id': 'u1',
+              'role': role,
+              if (hotelId != null) 'hotel_id': hotelId,
+            });
+
+        expect(withRole('guest').role, UserRole.guest);
+        expect(
+          withRole('hotel_staff', hotelId: 'h1').role,
+          UserRole.hotelStaff,
+        );
+        expect(withRole('admin').role, UserRole.admin);
+      });
+
+      test('tolerates a missing full_name', () {
+        final user = User.fromJson(const {'id': 'u1', 'role': 'guest'});
+        expect(user.fullName, isNull);
+      });
+    });
+
+    group('construction invariant', () {
+      test('rejects a hotel_staff user with no hotelId (via fromJson)', () {
+        expect(
+          () => User.fromJson(const {'id': 'u2', 'role': 'hotel_staff'}),
+          throwsArgumentError,
+        );
+      });
+
+      test('rejects a directly-constructed hotel_staff with no hotelId', () {
+        // A runtime throw (not an assert), so it also fires in release builds.
+        expect(
+          () => User(id: 'u2', role: UserRole.hotelStaff),
+          throwsArgumentError,
+        );
+      });
+
+      test('rejects a guest that carries a hotelId', () {
+        expect(
+          () => User.fromJson(const {
+            'id': 'u1',
+            'role': 'guest',
+            'hotel_id': 'h1',
+          }),
+          throwsArgumentError,
+        );
+      });
+
+      test('rejects an admin that carries a hotelId', () {
+        expect(
+          () => User(id: 'u3', role: UserRole.admin, hotelId: 'h1'),
+          throwsArgumentError,
+        );
+      });
+
+      test('accepts a hotel_staff user that carries a hotelId', () {
+        expect(
+          () => User.fromJson(const {
+            'id': 'u2',
+            'role': 'hotel_staff',
+            'hotel_id': 'h1',
+          }),
+          returnsNormally,
+        );
+      });
+
+      test('allows guests and admins with no hotelId', () {
+        expect(
+          () => User.fromJson(const {'id': 'u1', 'role': 'guest'}),
+          returnsNormally,
+        );
+        expect(
+          () => User.fromJson(const {'id': 'u3', 'role': 'admin'}),
+          returnsNormally,
+        );
+      });
+    });
+
+    test('round-trips a hotel_staff profile through toJson/fromJson', () {
+      final user = User(
+        id: 'u2',
+        role: UserRole.hotelStaff,
+        fullName: 'Grace Hopper',
+        hotelId: 'h1',
+      );
+
+      final json = user.toJson();
+      expect(json['role'], 'hotel_staff');
+      expect(json['full_name'], 'Grace Hopper');
+      expect(json['hotel_id'], 'h1');
+      expect(User.fromJson(json), equals(user));
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Implements BE-802 (#182): backend-agnostic domain entities that model the *problem*, not the database row.

- **New `User` value type** — the app-side view of a `profiles` row (BE-101). Immutable with value equality (equatable), snake_case JSON via `json_serializable`.
- **`UserRole` enum** mapped to the Postgres `user_role` values (`guest` / `hotel_staff` / `admin`), so UI/business rules never touch column-name strings.
- **`User` construction guard (both directions):** `hotel_staff` must carry a `hotelId`; `guest`/`admin` must not — the documented `profiles.hotel_id` contract.
- **`Reservation` payment-audit guard:** `paidBy` and `paidAt` must be set together (both or neither). These are written as a pair by `mark_reservation_paid` (BE-702); a half-stamped row is an incoherent audit record.
  - Deliberately **not** the "confirmed ⇒ paidAt" rule the issue floats as an example: `confirm_reservation` (BE-503) is a distinct staff action that transitions a hold to `confirmed` **without** taking payment, so `confirmed` + no payment stamp is a valid state. Encoding the literal example would reject legitimate confirmations.
- Both invariants are **unconditional runtime throws (`ArgumentError`), not asserts**, so they still hold in release builds where asserts are stripped (raised in CodeRabbit review).
- **No forbidden dependencies:** the package resolves to only `equatable` + `json_annotation` — no `supabase_flutter`, `data_models`, or Flutter. It compiles in isolation.

Closes #182

## Test plan

- [x] `User`: value equality, per-role enum decode (incl. `hotel_staff` ↔ `hotel_staff` JSON), null `full_name`/`hotel_id`, toJson/fromJson round-trip
- [x] `User` invariant: rejects staff-without-hotel and guest/admin-with-hotel, via both `fromJson` and direct construction; accepts valid combinations
- [x] `Reservation` invariant: rejects `paidBy` xor `paidAt` (via fromJson and direct ctor); accepts fully-stamped and unstamped rows; a `confirmed` reservation with no payment stamp is allowed (BE-503)
- [x] `melos analyze --no-select` clean across all packages (`--fatal-infos`)
- [x] `melos test --no-select` green across all packages (domain: 46 tests)
- [x] CodeRabbit review run; assert→runtime-throw feedback addressed

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added user profiles with guest, hotel staff, and administrator roles.
  - Added JSON conversion for user profile data, including names and hotel associations.

- **Bug Fixes**
  - Added validation to prevent incomplete payment records.
  - Enforced valid hotel association rules for user roles.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->