### PR TITLE
feat(domain): repository interfaces + Guest/Message/Hold entities (BE-803)

### DIFF
--- a/packages/hotelyn_domain/lib/hotelyn_domain.dart
+++ b/packages/hotelyn_domain/lib/hotelyn_domain.dart
@@ -2,8 +2,16 @@
 library;
 
 export 'src/auth_session.dart';
+export 'src/guest.dart';
 export 'src/hotel.dart';
+export 'src/message.dart';
+export 'src/repositories/auth_repository.dart';
+export 'src/repositories/hotel_repository.dart';
+export 'src/repositories/message_repository.dart';
+export 'src/repositories/reservation_repository.dart';
+export 'src/repositories/room_repository.dart';
 export 'src/reservation.dart';
+export 'src/reservation_hold.dart';
 export 'src/room.dart';
 export 'src/staff_room.dart';
 export 'src/user.dart';

--- a/packages/hotelyn_domain/lib/src/guest.dart
+++ b/packages/hotelyn_domain/lib/src/guest.dart
@@ -1,0 +1,31 @@
+import 'package:equatable/equatable.dart';
+
+/// A booking guest — the lightweight identity of the person a `Reservation` or
+/// `Message` belongs to.
+///
+/// Distinct from `User` (the full `profiles` view carrying a role and hotel
+/// scope): a `Guest` is just who-they-are in a booking context — an id, an
+/// optional display name, and an optional contact email. Repository methods
+/// that only need to name the guest take/return this, not the richer `User`.
+///
+/// A pure value type: value equality via [Equatable], no JSON coupling (this is
+/// a shared vocabulary contract, not a wire shape).
+class Guest extends Equatable {
+  const Guest({
+    required this.id,
+    this.fullName,
+    this.email,
+  });
+
+  /// The guest's id — the same uuid as their `profiles` / `auth.users` row.
+  final String id;
+
+  /// Display name, when known. `null` if the profile carries none.
+  final String? fullName;
+
+  /// Contact email, when known. `null` if unavailable in the calling context.
+  final String? email;
+
+  @override
+  List<Object?> get props => [id, fullName, email];
+}

--- a/packages/hotelyn_domain/lib/src/message.dart
+++ b/packages/hotelyn_domain/lib/src/message.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+
+/// A message exchanged about a reservation — a guest ↔ hotel note or
+/// notification.
+///
+/// Forward-looking shared vocabulary: no backend `messages` table exists yet,
+/// so this defines the contract a future messaging feature (and its
+/// `MessageRepository`) will speak, without committing to a wire shape.
+///
+/// A pure value type: value equality via [Equatable], no JSON coupling.
+class Message extends Equatable {
+  const Message({
+    required this.id,
+    required this.reservationId,
+    required this.senderId,
+    required this.body,
+    required this.sentAt,
+  });
+
+  /// The message's id.
+  final String id;
+
+  /// The reservation this message is about — the thread it belongs to.
+  final String reservationId;
+
+  /// The id of whoever sent it (a guest or a staff member).
+  final String senderId;
+
+  /// The message text.
+  final String body;
+
+  /// When the message was sent.
+  final DateTime sentAt;
+
+  @override
+  List<Object?> get props => [id, reservationId, senderId, body, sentAt];
+}

--- a/packages/hotelyn_domain/lib/src/repositories/auth_repository.dart
+++ b/packages/hotelyn_domain/lib/src/repositories/auth_repository.dart
@@ -1,0 +1,29 @@
+import 'package:hotelyn_domain/src/auth_session.dart';
+import 'package:hotelyn_domain/src/user.dart';
+
+/// Authentication: guest email-OTP sign-in and staff password login.
+///
+/// A shared-vocabulary contract implemented by the service layer (BE-902).
+/// Domain types only.
+abstract class AuthRepository {
+  /// Requests an email OTP for [email] (guest sign-in). Completes once the code
+  /// is on its way.
+  Future<void> requestEmailOtp({required String email});
+
+  /// Verifies the [token] a guest received for [email], returning the
+  /// authenticated [AuthSession].
+  Future<AuthSession> verifyEmailOtp({
+    required String email,
+    required String token,
+  });
+
+  /// Signs a staff member in with [email] and [password], returning the
+  /// authenticated [AuthSession].
+  Future<AuthSession> signInWithPassword({
+    required String email,
+    required String password,
+  });
+
+  /// The [User] the [accessToken] belongs to, or `null` if it is not valid.
+  Future<User?> currentUser(String accessToken);
+}

--- a/packages/hotelyn_domain/lib/src/repositories/hotel_repository.dart
+++ b/packages/hotelyn_domain/lib/src/repositories/hotel_repository.dart
@@ -1,0 +1,26 @@
+import 'package:hotelyn_domain/src/hotel.dart';
+
+/// Read access to the hotel catalogue and proximity search.
+///
+/// A shared-vocabulary contract: the Dart Frog service layer (BE-902)
+/// implements it, and any future client speaks the same interface. Every method
+/// takes and returns domain types only — no Supabase `PostgrestList`, no Ferry
+/// `GData`.
+abstract class HotelRepository {
+  /// Hotels within [radiusKm] of ([latitude], [longitude]), nearest-first.
+  Future<List<Hotel>> nearbyHotels({
+    required double latitude,
+    required double longitude,
+    required double radiusKm,
+  });
+
+  /// Popular-yet-nearby hotels within [radiusKm] of ([latitude], [longitude]).
+  Future<List<Hotel>> recommendedHotels({
+    required double latitude,
+    required double longitude,
+    required double radiusKm,
+  });
+
+  /// The hotel with [hotelId], or `null` if none exists.
+  Future<Hotel?> hotelById(String hotelId);
+}

--- a/packages/hotelyn_domain/lib/src/repositories/message_repository.dart
+++ b/packages/hotelyn_domain/lib/src/repositories/message_repository.dart
@@ -1,0 +1,19 @@
+import 'package:hotelyn_domain/src/message.dart';
+
+/// Messaging about a reservation — the guest ↔ hotel thread.
+///
+/// Forward-looking: no backend messaging exists yet, so this defines the
+/// contract a future feature (and the service layer, BE-902) will implement.
+/// Domain types only.
+abstract class MessageRepository {
+  /// The messages on [reservationId]'s thread, oldest-first.
+  Future<List<Message>> messagesForReservation(String reservationId);
+
+  /// Sends [body] from [senderId] on [reservationId]'s thread, returning the
+  /// created [Message].
+  Future<Message> sendMessage({
+    required String reservationId,
+    required String senderId,
+    required String body,
+  });
+}

--- a/packages/hotelyn_domain/lib/src/repositories/reservation_repository.dart
+++ b/packages/hotelyn_domain/lib/src/repositories/reservation_repository.dart
@@ -1,0 +1,42 @@
+import 'package:hotelyn_domain/src/reservation.dart';
+import 'package:hotelyn_domain/src/reservation_hold.dart';
+
+/// The reservation lifecycle: placing a hold, then confirming, rejecting, or
+/// marking it paid.
+///
+/// A shared-vocabulary contract implemented by the service layer (BE-902).
+/// Domain types only.
+abstract class ReservationRepository {
+  /// Places a short-lived hold on [roomId] for [guestId] over the
+  /// [checkIn]–[checkOut] date range, returning the created [ReservationHold].
+  Future<ReservationHold> createHold({
+    required String roomId,
+    required String guestId,
+    required DateTime checkIn,
+    required DateTime checkOut,
+  });
+
+  /// Reservations placed by [guestId] (their "my bookings" list).
+  Future<List<Reservation>> reservationsForGuest(String guestId);
+
+  /// Confirms a held reservation as owning-hotel staff, returning the now
+  /// `confirmed` [Reservation]. [actorId] is the acting staff member.
+  Future<Reservation> confirm({
+    required String actorId,
+    required String reservationId,
+  });
+
+  /// Rejects a reservation and frees the room, returning the now `rejected`
+  /// [Reservation]. [actorId] is the acting staff member.
+  Future<Reservation> reject({
+    required String actorId,
+    required String reservationId,
+  });
+
+  /// Marks a held reservation paid in person, transitioning it to `confirmed`
+  /// and stamping who/when. [actorId] is the acting staff member.
+  Future<Reservation> markPaid({
+    required String actorId,
+    required String reservationId,
+  });
+}

--- a/packages/hotelyn_domain/lib/src/repositories/room_repository.dart
+++ b/packages/hotelyn_domain/lib/src/repositories/room_repository.dart
@@ -1,0 +1,28 @@
+import 'package:hotelyn_domain/src/room.dart';
+import 'package:hotelyn_domain/src/staff_room.dart';
+
+/// Access to rooms — guest-facing availability and the staff inventory view.
+///
+/// A shared-vocabulary contract implemented by the service layer (BE-902).
+/// Domain types only.
+abstract class RoomRepository {
+  /// Rooms for [hotelId], each with its computed guest-facing `availableNow`
+  /// flag. Omit [hotelId] for the whole catalogue.
+  Future<List<Room>> roomsWithAvailability({String? hotelId});
+
+  /// The acting staff member's own hotel rooms, each with a derived
+  /// [RoomStatus]. [actorId] is the calling user; [hotelId] is an optional
+  /// admin-only target.
+  Future<List<StaffRoom>> staffRooms({
+    required String actorId,
+    String? hotelId,
+  });
+
+  /// Sets [roomId]'s staff availability flag, returning the updated room with
+  /// its freshly derived status. [actorId] is the acting staff member.
+  Future<StaffRoom> setRoomAvailability({
+    required String actorId,
+    required String roomId,
+    required bool isAvailable,
+  });
+}

--- a/packages/hotelyn_domain/lib/src/reservation_hold.dart
+++ b/packages/hotelyn_domain/lib/src/reservation_hold.dart
@@ -1,0 +1,58 @@
+import 'package:equatable/equatable.dart';
+
+/// A short-lived hold placed on a room while a guest completes a booking
+/// (BE-401/BE-402).
+///
+/// A narrower projection of a `held` `Reservation`: where `Reservation` models
+/// the whole lifecycle (and so carries a *nullable* `holdExpiresAt` and no
+/// enforced status), a `ReservationHold` is specifically the live hold, with a
+/// **guaranteed non-null** [expiresAt] and a [confirmationCode]. Repository
+/// methods that create a hold return this, making "this is a ticking hold, and
+/// here is when it lapses" true by construction rather than by convention.
+///
+/// A pure value type: value equality via [Equatable], no JSON coupling.
+class ReservationHold extends Equatable {
+  const ReservationHold({
+    required this.id,
+    required this.hotelId,
+    required this.roomId,
+    required this.guestId,
+    required this.checkIn,
+    required this.checkOut,
+    required this.expiresAt,
+    required this.confirmationCode,
+  });
+
+  /// The underlying reservation's id.
+  final String id;
+
+  final String hotelId;
+  final String roomId;
+  final String guestId;
+
+  /// Check-in day (a calendar date; see `Reservation.checkIn` for the
+  /// UTC-anchored date contract).
+  final DateTime checkIn;
+
+  /// Check-out day.
+  final DateTime checkOut;
+
+  /// When the hold lapses and stops blocking the room. Never `null` — a live
+  /// hold always ticks.
+  final DateTime expiresAt;
+
+  /// Human-quotable booking handle (e.g. `HZ-3F7K9Q2A`), generated server-side.
+  final String confirmationCode;
+
+  @override
+  List<Object?> get props => [
+        id,
+        hotelId,
+        roomId,
+        guestId,
+        checkIn,
+        checkOut,
+        expiresAt,
+        confirmationCode,
+      ];
+}

--- a/packages/hotelyn_domain/test/guest_test.dart
+++ b/packages/hotelyn_domain/test/guest_test.dart
@@ -1,0 +1,29 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Guest', () {
+    test('supports value equality', () {
+      const a = Guest(id: 'g1', fullName: 'Ada', email: 'ada@x.com');
+      const b = Guest(id: 'g1', fullName: 'Ada', email: 'ada@x.com');
+      expect(a, equals(b));
+      expect(a.hashCode, b.hashCode);
+    });
+
+    test('differs when any field differs', () {
+      Guest guest({String id = 'g1', String name = 'Ada', String? email}) =>
+          Guest(id: id, fullName: name, email: email ?? 'ada@x.com');
+
+      final base = guest();
+      expect(base, isNot(equals(guest(id: 'g2')))); // id differs
+      expect(base, isNot(equals(guest(name: 'Bea')))); // fullName differs
+      expect(base, isNot(equals(guest(email: 'bea@x.com')))); // email differs
+    });
+
+    test('leaves fullName and email null by default', () {
+      const guest = Guest(id: 'g1');
+      expect(guest.fullName, isNull);
+      expect(guest.email, isNull);
+    });
+  });
+}

--- a/packages/hotelyn_domain/test/message_test.dart
+++ b/packages/hotelyn_domain/test/message_test.dart
@@ -1,0 +1,47 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('Message', () {
+    Message message({
+      String id = 'm1',
+      String reservationId = 'res-1',
+      String senderId = 'u1',
+      String body = 'Hi',
+      DateTime? sentAt,
+    }) =>
+        Message(
+          id: id,
+          reservationId: reservationId,
+          senderId: senderId,
+          body: body,
+          sentAt: sentAt ?? DateTime.utc(2026, 9, 1, 10, 30),
+        );
+
+    test('supports value equality', () {
+      expect(message(), equals(message()));
+      expect(message().hashCode, message().hashCode);
+    });
+
+    test('differs when any field differs', () {
+      final base = message();
+      expect(base, isNot(equals(message(id: 'm2'))));
+      expect(base, isNot(equals(message(reservationId: 'res-2'))));
+      expect(base, isNot(equals(message(senderId: 'u2'))));
+      expect(base, isNot(equals(message(body: 'Bye'))));
+      expect(
+        base,
+        isNot(equals(message(sentAt: DateTime.utc(2026, 9, 2)))),
+      );
+    });
+
+    test('exposes its fields', () {
+      final m = message();
+      expect(m.id, 'm1');
+      expect(m.reservationId, 'res-1');
+      expect(m.senderId, 'u1');
+      expect(m.body, 'Hi');
+      expect(m.sentAt, DateTime.utc(2026, 9, 1, 10, 30));
+    });
+  });
+}

--- a/packages/hotelyn_domain/test/repositories_test.dart
+++ b/packages/hotelyn_domain/test/repositories_test.dart
@@ -1,0 +1,257 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:test/test.dart';
+
+// These tests are the executable proof of the BE-803 contract: each repository
+// interface can be implemented with domain types alone — no Supabase, http, or
+// Ferry types leak into a signature. If a method's type ever changed to
+// something outside hotelyn_domain, these fakes would fail to compile.
+
+class _FakeHotelRepository implements HotelRepository {
+  @override
+  Future<List<Hotel>> nearbyHotels({
+    required double latitude,
+    required double longitude,
+    required double radiusKm,
+  }) async =>
+      const [Hotel(id: 'h1', name: 'Bay', city: 'Lima', country: 'Peru')];
+
+  @override
+  Future<List<Hotel>> recommendedHotels({
+    required double latitude,
+    required double longitude,
+    required double radiusKm,
+  }) async =>
+      const [];
+
+  @override
+  Future<Hotel?> hotelById(String hotelId) async => null;
+}
+
+class _FakeRoomRepository implements RoomRepository {
+  @override
+  Future<List<Room>> roomsWithAvailability({String? hotelId}) async => const [];
+
+  @override
+  Future<List<StaffRoom>> staffRooms({
+    required String actorId,
+    String? hotelId,
+  }) async =>
+      const [];
+
+  @override
+  Future<StaffRoom> setRoomAvailability({
+    required String actorId,
+    required String roomId,
+    required bool isAvailable,
+  }) async =>
+      StaffRoom(
+        id: roomId,
+        hotelId: 'h1',
+        name: '101',
+        roomType: 'double',
+        capacity: 2,
+        pricePerNight: 180,
+        isAvailable: isAvailable,
+        status: isAvailable ? RoomStatus.available : RoomStatus.unavailable,
+      );
+}
+
+class _FakeReservationRepository implements ReservationRepository {
+  @override
+  Future<ReservationHold> createHold({
+    required String roomId,
+    required String guestId,
+    required DateTime checkIn,
+    required DateTime checkOut,
+  }) async =>
+      ReservationHold(
+        id: 'res-1',
+        hotelId: 'h1',
+        roomId: roomId,
+        guestId: guestId,
+        checkIn: checkIn,
+        checkOut: checkOut,
+        expiresAt: DateTime.utc(2026, 9, 1, 0, 15),
+        confirmationCode: 'HZ-3F7K9Q2A',
+      );
+
+  @override
+  Future<List<Reservation>> reservationsForGuest(String guestId) async =>
+      const [];
+
+  @override
+  Future<Reservation> confirm({
+    required String actorId,
+    required String reservationId,
+  }) async =>
+      _reservation(reservationId, ReservationStatus.confirmed);
+
+  @override
+  Future<Reservation> reject({
+    required String actorId,
+    required String reservationId,
+  }) async =>
+      _reservation(reservationId, ReservationStatus.rejected);
+
+  @override
+  Future<Reservation> markPaid({
+    required String actorId,
+    required String reservationId,
+  }) async =>
+      Reservation(
+        id: reservationId,
+        hotelId: 'h1',
+        roomId: 'r1',
+        guestId: 'g1',
+        status: ReservationStatus.confirmed,
+        checkIn: DateTime.utc(2026, 9),
+        checkOut: DateTime.utc(2026, 9, 3),
+        paidBy: actorId,
+        paidAt: DateTime.utc(2026, 9, 1, 10, 30),
+      );
+
+  Reservation _reservation(String id, ReservationStatus status) => Reservation(
+        id: id,
+        hotelId: 'h1',
+        roomId: 'r1',
+        guestId: 'g1',
+        status: status,
+        checkIn: DateTime.utc(2026, 9),
+        checkOut: DateTime.utc(2026, 9, 3),
+      );
+}
+
+class _FakeAuthRepository implements AuthRepository {
+  @override
+  Future<void> requestEmailOtp({required String email}) async {}
+
+  @override
+  Future<AuthSession> verifyEmailOtp({
+    required String email,
+    required String token,
+  }) async =>
+      _session;
+
+  @override
+  Future<AuthSession> signInWithPassword({
+    required String email,
+    required String password,
+  }) async =>
+      _session;
+
+  @override
+  Future<User?> currentUser(String accessToken) async =>
+      User(id: 'u1', role: UserRole.guest);
+
+  static const _session = AuthSession(
+    accessToken: 'a',
+    refreshToken: 'r',
+    userId: 'u1',
+    expiresIn: 3600,
+    tokenType: 'bearer',
+  );
+}
+
+class _FakeMessageRepository implements MessageRepository {
+  @override
+  Future<List<Message>> messagesForReservation(String reservationId) async =>
+      const [];
+
+  @override
+  Future<Message> sendMessage({
+    required String reservationId,
+    required String senderId,
+    required String body,
+  }) async =>
+      Message(
+        id: 'm1',
+        reservationId: reservationId,
+        senderId: senderId,
+        body: body,
+        sentAt: DateTime.utc(2026, 9, 1, 10, 30),
+      );
+}
+
+void main() {
+  group('HotelRepository contract', () {
+    final HotelRepository repo = _FakeHotelRepository();
+
+    test('nearbyHotels returns domain Hotels', () async {
+      final hotels = await repo.nearbyHotels(
+        latitude: -12.11,
+        longitude: -77.03,
+        radiusKm: 5,
+      );
+      expect(hotels.single, isA<Hotel>());
+    });
+
+    test('hotelById can return null', () async {
+      expect(await repo.hotelById('missing'), isNull);
+    });
+  });
+
+  group('RoomRepository contract', () {
+    final RoomRepository repo = _FakeRoomRepository();
+
+    test('setRoomAvailability returns the updated StaffRoom', () async {
+      final room = await repo.setRoomAvailability(
+        actorId: 'staff-1',
+        roomId: 'r1',
+        isAvailable: false,
+      );
+      expect(room.status, RoomStatus.unavailable);
+      expect(room.isAvailable, isFalse);
+    });
+  });
+
+  group('ReservationRepository contract', () {
+    final ReservationRepository repo = _FakeReservationRepository();
+
+    test('createHold returns a ReservationHold with a non-null expiry',
+        () async {
+      final hold = await repo.createHold(
+        roomId: 'r1',
+        guestId: 'g1',
+        checkIn: DateTime.utc(2026, 9),
+        checkOut: DateTime.utc(2026, 9, 3),
+      );
+      expect(hold, isA<ReservationHold>());
+      expect(hold.expiresAt, isNotNull);
+    });
+
+    test('markPaid returns a confirmed, paid Reservation', () async {
+      final reservation =
+          await repo.markPaid(actorId: 'staff-1', reservationId: 'res-1');
+      expect(reservation.status, ReservationStatus.confirmed);
+      expect(reservation.paidBy, 'staff-1');
+      expect(reservation.paidAt, isNotNull);
+    });
+  });
+
+  group('AuthRepository contract', () {
+    final AuthRepository repo = _FakeAuthRepository();
+
+    test('verifyEmailOtp returns an AuthSession', () async {
+      final session = await repo.verifyEmailOtp(email: 'a@x.com', token: '123');
+      expect(session, isA<AuthSession>());
+    });
+
+    test('currentUser returns a domain User', () async {
+      expect(await repo.currentUser('token'), isA<User>());
+    });
+  });
+
+  group('MessageRepository contract', () {
+    final MessageRepository repo = _FakeMessageRepository();
+
+    test('sendMessage returns the created Message', () async {
+      final message = await repo.sendMessage(
+        reservationId: 'res-1',
+        senderId: 'u1',
+        body: 'Hi',
+      );
+      expect(message.body, 'Hi');
+      expect(message.reservationId, 'res-1');
+    });
+  });
+}

--- a/packages/hotelyn_domain/test/reservation_hold_test.dart
+++ b/packages/hotelyn_domain/test/reservation_hold_test.dart
@@ -1,0 +1,42 @@
+import 'package:hotelyn_domain/hotelyn_domain.dart';
+import 'package:test/test.dart';
+
+void main() {
+  group('ReservationHold', () {
+    ReservationHold hold({
+      String id = 'res-1',
+      DateTime? expiresAt,
+      String confirmationCode = 'HZ-3F7K9Q2A',
+    }) =>
+        ReservationHold(
+          id: id,
+          hotelId: 'h1',
+          roomId: 'r1',
+          guestId: 'g1',
+          checkIn: DateTime.utc(2026, 9),
+          checkOut: DateTime.utc(2026, 9, 3),
+          expiresAt: expiresAt ?? DateTime.utc(2026, 9, 1, 0, 15),
+          confirmationCode: confirmationCode,
+        );
+
+    test('supports value equality', () {
+      expect(hold(), equals(hold()));
+      expect(hold().hashCode, hold().hashCode);
+    });
+
+    test('differs when a field differs', () {
+      expect(hold(), isNot(equals(hold(id: 'res-2'))));
+      expect(hold(), isNot(equals(hold(confirmationCode: 'HZ-OTHER'))));
+      expect(
+        hold(),
+        isNot(equals(hold(expiresAt: DateTime.utc(2026, 9, 1, 0, 30)))),
+      );
+    });
+
+    test('carries a non-null expiry and confirmation code', () {
+      final h = hold();
+      expect(h.expiresAt, DateTime.utc(2026, 9, 1, 0, 15));
+      expect(h.confirmationCode, 'HZ-3F7K9Q2A');
+    });
+  });
+}

--- a/packages/hotelyn_domain/test/reservation_hold_test.dart
+++ b/packages/hotelyn_domain/test/reservation_hold_test.dart
@@ -5,16 +5,21 @@ void main() {
   group('ReservationHold', () {
     ReservationHold hold({
       String id = 'res-1',
+      String hotelId = 'h1',
+      String roomId = 'r1',
+      String guestId = 'g1',
+      DateTime? checkIn,
+      DateTime? checkOut,
       DateTime? expiresAt,
       String confirmationCode = 'HZ-3F7K9Q2A',
     }) =>
         ReservationHold(
           id: id,
-          hotelId: 'h1',
-          roomId: 'r1',
-          guestId: 'g1',
-          checkIn: DateTime.utc(2026, 9),
-          checkOut: DateTime.utc(2026, 9, 3),
+          hotelId: hotelId,
+          roomId: roomId,
+          guestId: guestId,
+          checkIn: checkIn ?? DateTime.utc(2026, 9),
+          checkOut: checkOut ?? DateTime.utc(2026, 9, 3),
           expiresAt: expiresAt ?? DateTime.utc(2026, 9, 1, 0, 15),
           confirmationCode: confirmationCode,
         );
@@ -26,6 +31,17 @@ void main() {
 
     test('differs when a field differs', () {
       expect(hold(), isNot(equals(hold(id: 'res-2'))));
+      expect(hold(), isNot(equals(hold(hotelId: 'h2'))));
+      expect(hold(), isNot(equals(hold(roomId: 'r2'))));
+      expect(hold(), isNot(equals(hold(guestId: 'g2'))));
+      expect(
+        hold(),
+        isNot(equals(hold(checkIn: DateTime.utc(2026, 9, 2)))),
+      );
+      expect(
+        hold(),
+        isNot(equals(hold(checkOut: DateTime.utc(2026, 9, 4)))),
+      );
       expect(hold(), isNot(equals(hold(confirmationCode: 'HZ-OTHER'))));
       expect(
         hold(),


### PR DESCRIPTION
## Summary

Implements BE-803 (#183): the shared-vocabulary repository contracts and the remaining domain entities, so the server and any future client speak a common language without coupling to Supabase or Ferry types.

**Repository interfaces** (pure abstract, domain-typed only — the Dart Frog service layer implements them in BE-902; no shipped code is rewired here):
- `HotelRepository`, `RoomRepository`, `ReservationRepository`, `AuthRepository`, `MessageRepository`
- Every method takes/returns domain entities only — no Supabase `PostgrestList`, no Ferry `GData`.

**Entities** (simple value types via `equatable`, no hand-written JSON):
- `ReservationHold` — a held-reservation projection with a **guaranteed non-null** `expiresAt` + `confirmationCode` (the value it adds over `Reservation`, whose `holdExpiresAt` is nullable).
- `Guest` — the lightweight booking identity (`id`, `fullName?`, `email?`), distinct from the role-carrying `User` from BE-802.
- `Message` — forward-looking messaging contract. **Note:** there is no `messages` table in the schema and the app's Messages tab is currently mock-only, so this (and `MessageRepository`) is a contract ahead of backend support, per the issue's "shared vocabulary" framing.

**Package/deps:** `hotelyn_domain` is already in the Dart workspace + Melos. Its dependencies remain `equatable` + `json_annotation` only — verified no `supabase`, `ferry`, or `flutter`.

### Design notes (decisions I made explicit)
- `Hotel`, `Room`, `Reservation` already existed (BE-802 and earlier), so this issue only adds the three new entities.
- Repository docstrings reference the entities via imports of the specific `src/*.dart` files (not the package barrel) to avoid a `lib/src` file importing its own barrel.

Closes #183

## Test plan

- [x] Value-equality + per-field inequality tests for `Guest`, `Message`, `ReservationHold` (incl. `hashCode`)
- [x] `repositories_test.dart` implements all 5 interfaces with fakes — compile-time proof that every signature is expressible in domain types alone
- [x] Fakes return correct domain shapes (e.g. `createHold` → `ReservationHold` with non-null expiry; `markPaid` → confirmed+paid `Reservation`)
- [x] `melos analyze --no-select` clean across all packages (`--fatal-infos`)
- [x] `melos test --no-select` green across all packages (domain: 63 tests)
- [ ] CodeRabbit: could not complete — the account's review rate limit was reached during the prior issue and needs ~36 min to reset (paid usage-based reviews left disabled). Self-review performed in its place: clarified the `Guest` equality test and removed a self-barrel-import anti-pattern.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added guest, messaging, and reservation-hold domain models.
  * Added interfaces for authentication, hotel discovery, room availability, reservations, and messaging.
  * Expanded the domain package’s public exports for easier access to these capabilities.

* **Tests**
  * Added coverage for model equality, reservation holds, repository contracts, and key domain behaviors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->