### PR TITLE
feat(edge-functions): scaffold Deno Edge Functions workspace (INFRA-901)

### DIFF
--- a/.github/workflows/ci-edge-functions.yml
+++ b/.github/workflows/ci-edge-functions.yml
@@ -34,7 +34,6 @@ jobs:
     permissions:
       contents: read
     timeout-minutes: 10
-    timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7
         with:

--- a/.github/workflows/ci-edge-functions.yml
+++ b/.github/workflows/ci-edge-functions.yml
@@ -31,6 +31,9 @@ defaults:
 jobs:
   deno:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    timeout-minutes: 10
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v7

--- a/.github/workflows/ci-edge-functions.yml
+++ b/.github/workflows/ci-edge-functions.yml
@@ -1,0 +1,59 @@
+name: ci-edge-functions
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+# INFRA-901: Edge Functions (Deno/TS) get their own isolated CI, entirely
+# separate from the Dart/Melos pipeline. The path filter keeps this workflow a
+# no-op unless something under `supabase/functions/` changes, so webhook code
+# can evolve without entangling — or being blocked by — the Dart side.
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - "supabase/functions/**"
+      - "supabase/config.toml"
+      - ".github/workflows/ci-edge-functions.yml"
+  pull_request:
+    branches:
+      - main
+    paths:
+      - "supabase/functions/**"
+      - "supabase/config.toml"
+      - ".github/workflows/ci-edge-functions.yml"
+
+defaults:
+  run:
+    working-directory: supabase/functions
+
+jobs:
+  deno:
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # This job only reads the checkout to lint and test; it never pushes.
+          # Keep the GITHUB_TOKEN out of the local git config.
+          persist-credentials: false
+
+      - uses: denoland/setup-deno@v2
+        with:
+          # Pinned (not a floating range) so an unrelated Deno release can't turn
+          # a green PR red between runs; bump deliberately.
+          deno-version: "2.7.3"
+
+      - name: Lint
+        run: deno lint
+
+      - name: Format check
+        run: deno fmt --check
+
+      # --frozen fails the run if deno.lock is missing or out of date, so the
+      # committed lockfile is the single source of truth for dependency
+      # versions and integrity hashes — the same commit can't resolve to
+      # different dependency code between runs.
+      - name: Test
+        run: deno test --frozen --allow-env

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -448,3 +448,17 @@ enabled = true
 # declarative_schema_path = "./database"
 # JSON string passed through to pg-delta SQL formatting.
 # format_options = "{\"keywordCase\":\"upper\",\"indent\":2,\"maxWidth\":80,\"commaStyle\":\"trailing\"}"
+
+# INFRA-901: placeholder webhook. External providers can't present a Supabase
+# JWT, so verify_jwt is off; authenticate via a provider signing secret inside
+# the handler instead. The import map is the shared workspace deno.json.
+[functions.webhook-placeholder]
+enabled = true
+verify_jwt = false
+import_map = "./functions/deno.json"
+# Uncomment to specify a custom file path to the entrypoint.
+# Supported file extensions are: .ts, .js, .mjs, .jsx, .tsx
+entrypoint = "./functions/webhook-placeholder/index.ts"
+# Specifies static files to be bundled with the function. Supports glob patterns.
+# For example, if you want to serve static HTML pages in your function:
+# static_files = [ "./functions/webhook-placeholder/*.html" ]

--- a/supabase/functions/README.md
+++ b/supabase/functions/README.md
@@ -1,0 +1,79 @@
+# Edge Functions (Deno / TypeScript)
+
+Supabase Edge Functions for Hotelyn. This workspace is **isolated** from the
+Dart monorepo: it has its own `deno.json`, its own CI job
+(`.github/workflows/ci-edge-functions.yml`), and its own toolchain (Deno). It
+imports **nothing** from `packages/*` or `backend/*` and shares **no** type with
+the Dart side.
+
+## ⚠️ Use for external HTTP callbacks only
+
+Edge Functions here are **webhooks-only**: external HTTP callbacks such as
+
+- payment provider notifications,
+- SMS delivery receipts,
+- third-party push-notification hooks.
+
+**No hold / availability / user-auth / messaging logic lives here.** All
+business logic — GraphQL resolvers, user/application authentication, realtime,
+holds, availability, messaging — lives in the Dart Frog server
+(`hotelyn_server`, INFRA-1005). Edge Functions must never duplicate logic that
+already exists in the Dart server; they receive an external callback, do minimal
+validation, and hand off to the Dart server or Supabase.
+
+Verifying the **provider's** webhook signature (see [Authentication](#authentication)
+below) is not application auth — it only proves the callback came from the
+expected provider. That check belongs here; everything downstream of it does
+not.
+
+## Layout
+
+```
+supabase/functions/
+├── deno.json               # Deno config + import map for the whole workspace
+├── README.md               # this file
+└── webhook-placeholder/    # placeholder webhook (replace with real handlers)
+    ├── index.ts
+    └── index.test.ts
+```
+
+## Local development
+
+```bash
+# Lint
+deno lint
+
+# Test (handlers read the signing secret from the env — no network access)
+deno test --allow-env
+
+# Format
+deno fmt
+
+# Serve a single function locally (requires `supabase start`)
+supabase functions serve webhook-placeholder
+```
+
+## Authentication
+
+`verify_jwt` is **off** for webhook functions (external providers can't present
+a Supabase JWT), so each handler authenticates the caller itself. The
+placeholder verifies an HMAC-SHA256 signature of the raw request body against a
+shared secret and **fails closed**:
+
+| Condition                                      | Response |
+| ---------------------------------------------- | -------- |
+| Non-`POST` method                              | `405`    |
+| `WEBHOOK_SIGNING_SECRET` not configured        | `500`    |
+| `x-webhook-signature` header missing           | `401`    |
+| Signature doesn't match the body               | `401`    |
+| Valid signature                                | `200`    |
+
+Real handlers must keep an equivalent provider-signature check — never accept an
+unauthenticated callback.
+
+## Secrets
+
+Never commit secrets. Provide the signing secret (`WEBHOOK_SIGNING_SECRET`) and
+any provider API keys through Supabase function secrets
+(`supabase secrets set WEBHOOK_SIGNING_SECRET=...`) or the local
+`supabase/functions/.env` file, which is git-ignored.

--- a/supabase/functions/deno.json
+++ b/supabase/functions/deno.json
@@ -1,0 +1,16 @@
+{
+  "lint": {
+    "rules": {
+      "tags": ["recommended"]
+    }
+  },
+  "fmt": {
+    "lineWidth": 100,
+    "semiColons": true,
+    "singleQuote": false,
+    "exclude": ["**/*.md"]
+  },
+  "imports": {
+    "@std/assert": "jsr:@std/assert@^1"
+  }
+}

--- a/supabase/functions/deno.lock
+++ b/supabase/functions/deno.lock
@@ -1,0 +1,23 @@
+{
+  "version": "5",
+  "specifiers": {
+    "jsr:@std/assert@1": "1.0.18",
+    "jsr:@std/internal@^1.0.12": "1.0.14"
+  },
+  "jsr": {
+    "@std/assert@1.0.18": {
+      "integrity": "270245e9c2c13b446286de475131dc688ca9abcd94fc5db41d43a219b34d1c78",
+      "dependencies": [
+        "jsr:@std/internal"
+      ]
+    },
+    "@std/internal@1.0.14": {
+      "integrity": "291516b3d4c35024d6ffbc0a9df5bf4c64116e05b50012cf846710152d2ffdf7"
+    }
+  },
+  "workspace": {
+    "dependencies": [
+      "jsr:@std/assert@1"
+    ]
+  }
+}

--- a/supabase/functions/webhook-placeholder/index.test.ts
+++ b/supabase/functions/webhook-placeholder/index.test.ts
@@ -1,0 +1,93 @@
+import { assertEquals } from "@std/assert";
+
+import { handleWebhook } from "./index.ts";
+
+const SECRET = "test-signing-secret";
+const BODY = JSON.stringify({ event: "ping" });
+
+/** Compute the hex HMAC-SHA256 the handler expects, for a given body/secret. */
+async function signature(secret: string, body: string): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const digest = await crypto.subtle.sign(
+    "HMAC",
+    key,
+    new TextEncoder().encode(body).buffer,
+  );
+  return Array.from(new Uint8Array(digest))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+function request(
+  { method = "POST", body = BODY, sig }: {
+    method?: string;
+    body?: string;
+    sig?: string;
+  } = {},
+): Request {
+  const headers = new Headers();
+  if (sig !== undefined) headers.set("x-webhook-signature", sig);
+  return new Request("http://localhost/webhook-placeholder", {
+    method,
+    headers,
+    body: method === "GET" ? undefined : body,
+  });
+}
+
+Deno.test("non-POST methods are rejected with 405", async () => {
+  Deno.env.set("WEBHOOK_SIGNING_SECRET", SECRET);
+  for (const method of ["GET", "PUT", "DELETE", "PATCH"]) {
+    const response = await handleWebhook(request({ method }));
+    assertEquals(response.status, 405, `${method} should be rejected`);
+    assertEquals(response.headers.get("allow"), "POST");
+    assertEquals(await response.json(), { error: "method_not_allowed" });
+  }
+});
+
+Deno.test("returns 500 when the signing secret is not configured", async () => {
+  Deno.env.delete("WEBHOOK_SIGNING_SECRET");
+  const response = await handleWebhook(
+    request({ sig: await signature(SECRET, BODY) }),
+  );
+  assertEquals(response.status, 500);
+  assertEquals(await response.json(), { error: "server_misconfigured" });
+});
+
+Deno.test("returns 401 when the signature header is missing", async () => {
+  Deno.env.set("WEBHOOK_SIGNING_SECRET", SECRET);
+  const response = await handleWebhook(request());
+  assertEquals(response.status, 401);
+  assertEquals(await response.json(), { error: "missing_signature" });
+});
+
+Deno.test("returns 401 when the signature is invalid", async () => {
+  Deno.env.set("WEBHOOK_SIGNING_SECRET", SECRET);
+  const response = await handleWebhook(request({ sig: "deadbeef" }));
+  assertEquals(response.status, 401);
+  assertEquals(await response.json(), { error: "invalid_signature" });
+});
+
+Deno.test("returns 401 when the signature is for a different body", async () => {
+  Deno.env.set("WEBHOOK_SIGNING_SECRET", SECRET);
+  const response = await handleWebhook(
+    request({ sig: await signature(SECRET, "tampered") }),
+  );
+  assertEquals(response.status, 401);
+  assertEquals(await response.json(), { error: "invalid_signature" });
+});
+
+Deno.test("accepts a POST with a valid signature", async () => {
+  Deno.env.set("WEBHOOK_SIGNING_SECRET", SECRET);
+  const response = await handleWebhook(
+    request({ sig: await signature(SECRET, BODY) }),
+  );
+  assertEquals(response.status, 200);
+  assertEquals(response.headers.get("content-type"), "application/json");
+  assertEquals(await response.json(), { received: true });
+});

--- a/supabase/functions/webhook-placeholder/index.ts
+++ b/supabase/functions/webhook-placeholder/index.ts
@@ -1,0 +1,105 @@
+// Placeholder Edge Function (INFRA-901).
+//
+// Edge Functions are WEBHOOKS-ONLY: external HTTP callbacks such as payment
+// provider notifications, SMS delivery receipts, or third-party push hooks.
+// They MUST NOT contain hold/availability/auth/messaging business logic — that
+// lives in the Dart Frog server (hotelyn_server). See the README in this folder.
+//
+// JWT verification is disabled for this function (see supabase/config.toml)
+// because external providers can't present a Supabase JWT. Authentication is
+// therefore done in-handler by verifying an HMAC-SHA256 signature of the raw
+// body against a shared secret. This is the shape a real provider handler
+// should keep; replace the acknowledgement with real provider handling, but do
+// NOT drop the signature check and do NOT add domain logic here.
+
+/** Header carrying the hex-encoded HMAC-SHA256 signature of the raw body. */
+const SIGNATURE_HEADER = "x-webhook-signature";
+
+/** Env var holding the shared signing secret. Never commit its value. */
+const SECRET_ENV = "WEBHOOK_SIGNING_SECRET";
+
+function json(body: unknown, status: number, headers: HeadersInit = {}): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { "content-type": "application/json", ...headers },
+  });
+}
+
+/** Hex-encode bytes, e.g. for comparing an HMAC digest. */
+function toHex(bytes: ArrayBuffer): string {
+  return Array.from(new Uint8Array(bytes))
+    .map((b) => b.toString(16).padStart(2, "0"))
+    .join("");
+}
+
+/**
+ * Constant-time string comparison, so a caller can't learn the expected
+ * signature byte-by-byte from response timing.
+ */
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) {
+    diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return diff === 0;
+}
+
+/**
+ * Compute the hex HMAC-SHA256 of the raw `body` bytes under `secret`. Signing
+ * the original bytes (not a UTF-8 round-trip) keeps it correct for binary or
+ * non-UTF-8 payloads a provider might send.
+ */
+async function sign(secret: string, body: ArrayBuffer): Promise<string> {
+  const key = await crypto.subtle.importKey(
+    "raw",
+    new TextEncoder().encode(secret),
+    { name: "HMAC", hash: "SHA-256" },
+    false,
+    ["sign"],
+  );
+  const signature = await crypto.subtle.sign("HMAC", key, body);
+  return toHex(signature);
+}
+
+/**
+ * Handle an inbound webhook callback.
+ *
+ * - Only `POST` is accepted (405 otherwise).
+ * - The function must be configured with a signing secret (500 if missing —
+ *   it's a deployment error, not a caller error).
+ * - The request must carry a valid `x-webhook-signature` over the raw body
+ *   (401 if the header is missing or the signature doesn't match).
+ */
+export async function handleWebhook(request: Request): Promise<Response> {
+  if (request.method !== "POST") {
+    return json({ error: "method_not_allowed" }, 405, { allow: "POST" });
+  }
+
+  const secret = Deno.env.get(SECRET_ENV);
+  if (!secret) {
+    // Fail closed: never accept a webhook when we can't authenticate it.
+    return json({ error: "server_misconfigured" }, 500);
+  }
+
+  const provided = request.headers.get(SIGNATURE_HEADER);
+  if (!provided) {
+    return json({ error: "missing_signature" }, 401);
+  }
+
+  const body = await request.arrayBuffer();
+  const expected = await sign(secret, body);
+  if (!timingSafeEqual(provided, expected)) {
+    return json({ error: "invalid_signature" }, 401);
+  }
+
+  // Authenticated. A real handler would dispatch on the payload here; the
+  // placeholder just acknowledges receipt.
+  return json({ received: true }, 200);
+}
+
+// Only start the server when run as the entrypoint, so tests can import
+// `handleWebhook` without binding a port.
+if (import.meta.main) {
+  Deno.serve(handleWebhook);
+}


### PR DESCRIPTION
## Summary
- Scaffold an **isolated, webhooks-only** Deno Edge Functions area under `supabase/functions/`, kept entirely separate from the Dart/Melos pipeline (INFRA-901).
- Add a placeholder webhook function that authenticates callers with a **fail-closed HMAC-SHA256 signature check** over the raw body (JWT verification is off because external providers can't present a Supabase JWT); the shared secret comes from `WEBHOOK_SIGNING_SECRET` and is never committed.
- Workspace `deno.json` provides lint/fmt config + import map and imports **nothing** from `packages/*` or `backend/*` — no shared type with the Dart side.
- New `ci-edge-functions.yml` runs `deno lint` + `deno fmt --check` + `deno test --frozen`, triggered **only** on changes under `supabase/functions/` (plus `supabase/config.toml` and the workflow itself). Deno version pinned; committed `deno.lock` pins dependency versions/hashes.
- `supabase/functions/README.md` states the webhooks-only rule explicitly — **use for external HTTP callbacks only; no hold/availability/user-auth/messaging logic here** — and documents the auth model and secret handling.
- Register the function in `supabase/config.toml` with `verify_jwt = false` pointing at the shared workspace import map.

Closes #187

## Test plan
- [x] `deno lint` passes
- [x] `deno fmt --check` passes
- [x] `deno test --frozen --allow-env` passes (6 tests: method rejection, missing-secret 500, missing/invalid/tampered signature 401, valid signature 200)
- [x] `deno.lock` committed; CI uses `--frozen` for reproducible dependency resolution
- [x] No imports from `packages/*` or `backend/*`; production `index.ts` has no external imports
- [x] `supabase/config.toml` is valid TOML; workflow is valid YAML
- [x] No secret committed (`WEBHOOK_SIGNING_SECRET` via env; `.env` git-ignored)
- [ ] Edge CI job runs green on this PR, independently of the Dart CI

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a placeholder Edge Function webhook endpoint that accepts signed `POST` requests and returns an acknowledgement response after HMAC validation, with clear error handling for invalid/missing methods and signatures.
* **Documentation**
  * Added guidance for the Edge Functions workspace, including security expectations and how to provide webhook secrets.
* **Tests**
  * Added automated tests covering success and failure scenarios for webhook signature verification.
* **Chores**
  * Introduced Edge-Functions-focused CI checks (lint, format check, and tests) and added local Edge Function configuration plus Deno lint/format settings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->