### PR TITLE
feat(home): implement homepage scaffold and top-level navigation (FE-1301)

### DIFF
--- a/apps/hotelyn_app/lib/app/router/app_router.dart
+++ b/apps/hotelyn_app/lib/app/router/app_router.dart
@@ -2,6 +2,7 @@ import 'package:go_router/go_router.dart';
 import 'package:hotelyn/features/home/view/home_page.dart';
 import 'package:hotelyn/features/intro/intro.dart';
 import 'package:hotelyn/features/login/view/login_page.dart';
+import 'package:hotelyn/features/notifications/notifications.dart';
 import 'package:hotelyn/features/payment/view/payment_page.dart';
 import 'package:hotelyn/features/splash/view/splash_screen.dart';
 
@@ -28,6 +29,10 @@ class AppRouter {
       GoRoute(
         path: '/payment',
         builder: (context, state) => const PaymentPage(),
+      ),
+      GoRoute(
+        path: '/notifications',
+        builder: (context, state) => const NotificationsPage(),
       ),
     ],
   );

--- a/apps/hotelyn_app/lib/components/navigation_bar/navigation_bar.dart
+++ b/apps/hotelyn_app/lib/components/navigation_bar/navigation_bar.dart
@@ -1,7 +1,8 @@
+import 'package:california_ui/california_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-
 import 'package:hotelyn/components/navigation_bar/navigation_bar_cubit.dart';
+import 'package:hotelyn/components/theme/hotelyn_colors.dart';
 
 class HotelynNavigationBar extends StatelessWidget {
   const HotelynNavigationBar({super.key});
@@ -14,6 +15,11 @@ class HotelynNavigationBar extends StatelessWidget {
       currentIndex: cubit.state.selectedTabIndex,
       showSelectedLabels: true,
       type: BottomNavigationBarType.fixed,
+      backgroundColor: PrimaryColors.white,
+      selectedItemColor: CaliforniaColors.brandPrimary,
+      unselectedItemColor: GreyColors.grey,
+      selectedLabelStyle: CaliforniaTypography.p12Medium,
+      unselectedLabelStyle: CaliforniaTypography.p12Regular,
       items: const [
         BottomNavigationBarItem(
           icon: Icon(Icons.home),

--- a/apps/hotelyn_app/lib/components/navigation_bar/navigation_bar_cubit.dart
+++ b/apps/hotelyn_app/lib/components/navigation_bar/navigation_bar_cubit.dart
@@ -1,6 +1,5 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:hotelyn/components/navigation_bar/navigation_bar_state.dart';
-
 import 'package:hotelyn/core/services/clarity_service.dart';
 
 class NavigationBarCubit extends Cubit<NavigationBarState> {
@@ -12,10 +11,22 @@ class NavigationBarCubit extends Cubit<NavigationBarState> {
 
   final ClarityService clarityService;
 
+  static const homeIndex = 0;
+  static const searchIndex = 1;
+  static const messagesIndex = 2;
+  static const profileIndex = 3;
+
   static const _screenNames = ['home', 'search', 'messages', 'profile'];
 
   void updateSelectedIndex(int index) {
-    clarityService.setCurrentScreenName(_screenNames[index]);
-    emit(state.copyWith(selectedTabIndex: index));
+    if (index >= 0 && index < _screenNames.length) {
+      clarityService.setCurrentScreenName(_screenNames[index]);
+      emit(state.copyWith(selectedTabIndex: index));
+    }
   }
+
+  void switchToHome() => updateSelectedIndex(homeIndex);
+  void switchToSearch() => updateSelectedIndex(searchIndex);
+  void switchToMessages() => updateSelectedIndex(messagesIndex);
+  void switchToProfile() => updateSelectedIndex(profileIndex);
 }

--- a/apps/hotelyn_app/lib/components/text_input/hotelyn_search_input.dart
+++ b/apps/hotelyn_app/lib/components/text_input/hotelyn_search_input.dart
@@ -6,10 +6,20 @@ class HotelynSearchInput extends StatelessWidget {
     required this.hintText,
     super.key,
     this.controller,
+    this.onTap,
+    this.readOnly = false,
+    this.enabled,
+    this.onChanged,
+    this.onSubmitted,
   });
 
   final String hintText;
   final TextEditingController? controller;
+  final VoidCallback? onTap;
+  final bool readOnly;
+  final bool? enabled;
+  final ValueChanged<String>? onChanged;
+  final ValueChanged<String>? onSubmitted;
 
   double get _radius => 30;
 
@@ -17,6 +27,11 @@ class HotelynSearchInput extends StatelessWidget {
   Widget build(BuildContext context) {
     return TextField(
       controller: controller,
+      readOnly: readOnly,
+      enabled: enabled,
+      onTap: onTap,
+      onChanged: onChanged,
+      onSubmitted: onSubmitted,
       decoration: InputDecoration(
         filled: true,
         fillColor: LightGreyColors.lightGrey,

--- a/apps/hotelyn_app/lib/features/home/view/home_page.dart
+++ b/apps/hotelyn_app/lib/features/home/view/home_page.dart
@@ -14,55 +14,106 @@ import 'package:hotelyn/features/search/recent_search/cubit/search_cubit.dart';
 import 'package:hotelyn/features/search/recent_search/recent_search_tab.dart';
 
 class HomePage extends StatelessWidget {
-  const HomePage({super.key});
+  const HomePage({
+    super.key,
+    this.navigationBarCubit,
+    this.profileCubit,
+    this.messagesCubit,
+    this.searchCubit,
+  });
 
   static const route = '/home';
+
+  final NavigationBarCubit? navigationBarCubit;
+  final ProfileCubit? profileCubit;
+  final MessagesCubit? messagesCubit;
+  final SearchCubit? searchCubit;
 
   @override
   Widget build(BuildContext context) {
     return MultiBlocProvider(
       providers: [
-        BlocProvider(
-          create: (_) => NavigationBarCubit(
-            clarityService: context.read<ClarityService>(),
+        if (navigationBarCubit != null)
+          BlocProvider.value(value: navigationBarCubit!)
+        else
+          BlocProvider(
+            create: (context) => NavigationBarCubit(
+              clarityService: context.read<ClarityService>(),
+            ),
           ),
-        ),
-        BlocProvider(
-          create: (_) => ProfileCubit(),
-        ),
-        BlocProvider(
-          create: (_) => MessagesCubit(),
-        ),
-        BlocProvider(
-          create: (_) => SearchCubit(
-            clarityService: context.read<ClarityService>(),
+        if (profileCubit != null)
+          BlocProvider.value(value: profileCubit!)
+        else
+          BlocProvider(
+            create: (_) => ProfileCubit(),
           ),
-        ),
+        if (messagesCubit != null)
+          BlocProvider.value(value: messagesCubit!)
+        else
+          BlocProvider(
+            create: (_) => MessagesCubit(),
+          ),
+        if (searchCubit != null)
+          BlocProvider.value(value: searchCubit!)
+        else
+          BlocProvider(
+            create: (context) => SearchCubit(
+              clarityService: context.read<ClarityService>(),
+            ),
+          ),
       ],
-      child: BlocBuilder<NavigationBarCubit, NavigationBarState>(
-        builder: (context, state) {
-          final index = state.selectedTabIndex;
-          return Scaffold(
+      child: const HomeView(),
+    );
+  }
+}
+
+class HomeView extends StatelessWidget {
+  const HomeView({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<NavigationBarCubit, NavigationBarState>(
+      builder: (context, state) {
+        final index = state.selectedTabIndex;
+        return PopScope(
+          canPop: index == 0,
+          onPopInvokedWithResult: (didPop, result) {
+            if (didPop) return;
+            if (index != 0) {
+              context.read<NavigationBarCubit>().updateSelectedIndex(0);
+            }
+          },
+          child: Scaffold(
             bottomNavigationBar: const HotelynNavigationBar(),
             body: SafeArea(
-              child: <Widget>[
-                const HomeTab(),
-                const RecentSearchTab(),
-                const MessagesTab(),
-                const ProfileTab(),
-              ].elementAt(index),
+              child: IndexedStack(
+                index: index,
+                children: const [
+                  HomeTab(),
+                  RecentSearchTab(),
+                  MessagesTab(),
+                  ProfileTab(),
+                ],
+              ),
             ),
-          );
-        },
-      ),
+          ),
+        );
+      },
     );
   }
 }
 
 class HomeTab extends StatelessWidget {
   const HomeTab({
+    this.userName = 'Katherine',
+    this.onNotificationTap,
+    this.onSearchTap,
     super.key,
   });
+
+  final String userName;
+  final VoidCallback? onNotificationTap;
+  final VoidCallback? onSearchTap;
 
   @override
   Widget build(BuildContext context) {
@@ -70,7 +121,11 @@ class HomeTab extends StatelessWidget {
       slivers: [
         SliverPersistentHeader(
           pinned: true,
-          delegate: HotelynHeader(),
+          delegate: HotelynHeader(
+            userName: userName,
+            onNotificationTap: onNotificationTap,
+            onSearchTap: onSearchTap,
+          ),
         ),
         const FeaturedHotelsSection(),
       ],

--- a/apps/hotelyn_app/lib/features/home/widgets/home_header.dart
+++ b/apps/hotelyn_app/lib/features/home/widgets/home_header.dart
@@ -3,6 +3,8 @@ import 'dart:async';
 import 'package:california_ui/california_ui.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:go_router/go_router.dart';
+import 'package:hotelyn/components/navigation_bar/navigation_bar_cubit.dart';
 import 'package:hotelyn/components/text_input/hotelyn_search_input.dart';
 import 'package:hotelyn/components/text_style/hotelyn_text_style.dart';
 import 'package:hotelyn/components/theme/hotelyn_colors.dart';
@@ -10,18 +12,26 @@ import 'package:hotelyn/features/location/location.dart';
 
 const _cardElevation = 2.0;
 
-class HotelynHeader extends SliverPersistentHeaderDelegate {
-  final _maxExtent = 250.0;
-  final _minExtent = 240.0;
+class HomeHeader extends StatelessWidget {
+  const HomeHeader({
+    this.userName = 'Katherine',
+    this.onNotificationTap,
+    this.onSearchTap,
+    this.onLocationTap,
+    this.overlapsContent = false,
+    super.key,
+  });
+
+  final String userName;
+  final VoidCallback? onNotificationTap;
+  final VoidCallback? onSearchTap;
+  final VoidCallback? onLocationTap;
+  final bool overlapsContent;
 
   @override
-  Widget build(
-    BuildContext context,
-    double shrinkOffset,
-    bool overlapsContent,
-  ) {
+  Widget build(BuildContext context) {
     return ColoredBox(
-      color: Colors.white,
+      color: PrimaryColors.white,
       child: Padding(
         padding: const EdgeInsets.only(
           left: 24,
@@ -30,16 +40,16 @@ class HotelynHeader extends SliverPersistentHeaderDelegate {
         child: Column(
           crossAxisAlignment: CrossAxisAlignment.start,
           children: [
-            const Row(
+            Row(
               mainAxisAlignment: MainAxisAlignment.spaceBetween,
               children: [
-                LocationCard(),
-                NotificationCard(),
+                LocationCard(onTap: onLocationTap),
+                NotificationCard(onTap: onNotificationTap),
               ],
             ),
             const SizedBox(height: 32),
-            const Text(
-              'Hello, Katherine! 👋',
+            Text(
+              'Hello, $userName! 👋',
               style: HotelynTextStyle.description,
             ),
             const SizedBox(height: 8),
@@ -49,10 +59,54 @@ class HotelynHeader extends SliverPersistentHeaderDelegate {
             ),
             const SizedBox(height: 32),
             if (!overlapsContent)
-              const HotelynSearchInput(hintText: 'Search hotel'),
+              HotelynSearchInput(
+                hintText: 'Search hotel',
+                readOnly: true,
+                onTap:
+                    onSearchTap ??
+                    () {
+                      try {
+                        context.read<NavigationBarCubit>().updateSelectedIndex(
+                          1,
+                        );
+                      } on Exception catch (_) {}
+                    },
+              ),
           ],
         ),
       ),
+    );
+  }
+}
+
+class HotelynHeader extends SliverPersistentHeaderDelegate {
+  HotelynHeader({
+    this.userName = 'Katherine',
+    this.onNotificationTap,
+    this.onSearchTap,
+    this.onLocationTap,
+  });
+
+  final String userName;
+  final VoidCallback? onNotificationTap;
+  final VoidCallback? onSearchTap;
+  final VoidCallback? onLocationTap;
+
+  final _maxExtent = 250.0;
+  final _minExtent = 240.0;
+
+  @override
+  Widget build(
+    BuildContext context,
+    double shrinkOffset,
+    bool overlapsContent,
+  ) {
+    return HomeHeader(
+      userName: userName,
+      onNotificationTap: onNotificationTap,
+      onSearchTap: onSearchTap,
+      onLocationTap: onLocationTap,
+      overlapsContent: overlapsContent,
     );
   }
 
@@ -71,7 +125,10 @@ class HotelynHeader extends SliverPersistentHeaderDelegate {
 class LocationCard extends StatelessWidget {
   const LocationCard({
     super.key,
+    this.onTap,
   });
+
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
@@ -80,34 +137,36 @@ class LocationCard extends StatelessWidget {
         final cityName = state.userLocation.cityName;
 
         return GestureDetector(
-          onTap: () {
-            final cubit = context.read<LocationCubit>();
-            if (state.isDenied || state.userLocation.isManualFallback) {
-              unawaited(
-                ManualLocationSheet.show(
-                  context,
-                  initialLocation: state.userLocation,
-                  onLocationSelected: cubit.setManualLocation,
-                ),
-              );
-            } else {
-              unawaited(
-                LocationPrimingSheet.show<void>(
-                  context,
-                  onEnableLocation: cubit.requestPermissionFromPriming,
-                  onEnterManually: () {
-                    unawaited(
-                      ManualLocationSheet.show(
-                        context,
-                        initialLocation: state.userLocation,
-                        onLocationSelected: cubit.setManualLocation,
-                      ),
-                    );
-                  },
-                ),
-              );
-            }
-          },
+          onTap:
+              onTap ??
+              () {
+                final cubit = context.read<LocationCubit>();
+                if (state.isDenied || state.userLocation.isManualFallback) {
+                  unawaited(
+                    ManualLocationSheet.show(
+                      context,
+                      initialLocation: state.userLocation,
+                      onLocationSelected: cubit.setManualLocation,
+                    ),
+                  );
+                } else {
+                  unawaited(
+                    LocationPrimingSheet.show<void>(
+                      context,
+                      onEnableLocation: cubit.requestPermissionFromPriming,
+                      onEnterManually: () {
+                        unawaited(
+                          ManualLocationSheet.show(
+                            context,
+                            initialLocation: state.userLocation,
+                            onLocationSelected: cubit.setManualLocation,
+                          ),
+                        );
+                      },
+                    ),
+                  );
+                }
+              },
           child: Card(
             color: PrimaryColors.white,
             elevation: _cardElevation,
@@ -148,18 +207,28 @@ class LocationCard extends StatelessWidget {
 class NotificationCard extends StatelessWidget {
   const NotificationCard({
     super.key,
+    this.onTap,
   });
+
+  final VoidCallback? onTap;
 
   @override
   Widget build(BuildContext context) {
-    return const Card(
-      elevation: _cardElevation,
-      color: PrimaryColors.white,
-      shape: CircleBorder(),
-      child: Padding(
-        padding: EdgeInsets.all(11),
-        child: Badge(
-          child: Icon(Icons.notifications),
+    return GestureDetector(
+      onTap:
+          onTap ??
+          () {
+            unawaited(context.push('/notifications'));
+          },
+      child: const Card(
+        elevation: _cardElevation,
+        color: PrimaryColors.white,
+        shape: CircleBorder(),
+        child: Padding(
+          padding: EdgeInsets.all(11),
+          child: Badge(
+            child: Icon(Icons.notifications),
+          ),
         ),
       ),
     );

--- a/apps/hotelyn_app/lib/features/home/widgets/widgets.dart
+++ b/apps/hotelyn_app/lib/features/home/widgets/widgets.dart
@@ -1,1 +1,3 @@
-
+export 'featured_hotel_card.dart';
+export 'featured_hotels_section.dart';
+export 'home_header.dart';

--- a/apps/hotelyn_app/lib/features/notifications/notifications.dart
+++ b/apps/hotelyn_app/lib/features/notifications/notifications.dart
@@ -1,0 +1,1 @@
+export 'view/notifications_page.dart';

--- a/apps/hotelyn_app/lib/features/notifications/view/notifications_page.dart
+++ b/apps/hotelyn_app/lib/features/notifications/view/notifications_page.dart
@@ -1,0 +1,42 @@
+import 'package:flutter/material.dart';
+import 'package:hotelyn/components/app_bar.dart';
+import 'package:hotelyn/components/text_style/hotelyn_text_style.dart';
+import 'package:hotelyn/components/theme/hotelyn_colors.dart';
+
+class NotificationsPage extends StatelessWidget {
+  const NotificationsPage({super.key});
+
+  static const route = '/notifications';
+
+  @override
+  Widget build(BuildContext context) {
+    return const Scaffold(
+      appBar: HotelynHomeAppBar(
+        title: 'Notifications',
+        iconData: Icons.notifications_none,
+      ),
+      body: Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            Icon(
+              Icons.notifications_off_outlined,
+              size: 64,
+              color: GreyColors.grey,
+            ),
+            SizedBox(height: 16),
+            Text(
+              'No Notifications',
+              style: HotelynTextStyle.h2,
+            ),
+            SizedBox(height: 8),
+            Text(
+              'You have no unread notifications at the moment.',
+              style: HotelynTextStyle.description,
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/apps/hotelyn_app/test/components/navigation_bar/navigation_bar_cubit_test.dart
+++ b/apps/hotelyn_app/test/components/navigation_bar/navigation_bar_cubit_test.dart
@@ -37,5 +37,89 @@ void main() {
         const NavigationBarState(selectedTabIndex: 1),
       ],
     );
+
+    blocTest<NavigationBarCubit, NavigationBarState>(
+      'emits correct state for all valid tabs',
+      build: () => cubit,
+      act: (cubit) {
+        cubit
+          ..updateSelectedIndex(2)
+          ..updateSelectedIndex(3)
+          ..updateSelectedIndex(0);
+      },
+      verify: (_) {
+        verify(() => clarityService.setCurrentScreenName('messages')).called(1);
+        verify(() => clarityService.setCurrentScreenName('profile')).called(1);
+        verify(() => clarityService.setCurrentScreenName('home')).called(2);
+      },
+      expect: () => [
+        const NavigationBarState(selectedTabIndex: 2),
+        const NavigationBarState(selectedTabIndex: 3),
+        const NavigationBarState(selectedTabIndex: 0),
+      ],
+    );
+
+    blocTest<NavigationBarCubit, NavigationBarState>(
+      'ignores out of bounds negative index',
+      build: () => cubit,
+      act: (cubit) => cubit.updateSelectedIndex(-1),
+      expect: () => <NavigationBarState>[],
+    );
+
+    blocTest<NavigationBarCubit, NavigationBarState>(
+      'ignores out of bounds index >= 4',
+      build: () => cubit,
+      act: (cubit) => cubit.updateSelectedIndex(4),
+      expect: () => <NavigationBarState>[],
+    );
+
+    blocTest<NavigationBarCubit, NavigationBarState>(
+      'switchToHome emits index 0 and updates screen name',
+      build: () => cubit,
+      seed: () => const NavigationBarState(selectedTabIndex: 2),
+      act: (cubit) => cubit.switchToHome(),
+      verify: (_) {
+        verify(() => clarityService.setCurrentScreenName('home')).called(2);
+      },
+      expect: () => [
+        const NavigationBarState(selectedTabIndex: 0),
+      ],
+    );
+
+    blocTest<NavigationBarCubit, NavigationBarState>(
+      'switchToSearch emits index 1 and updates screen name',
+      build: () => cubit,
+      act: (cubit) => cubit.switchToSearch(),
+      verify: (_) {
+        verify(() => clarityService.setCurrentScreenName('search')).called(1);
+      },
+      expect: () => [
+        const NavigationBarState(selectedTabIndex: 1),
+      ],
+    );
+
+    blocTest<NavigationBarCubit, NavigationBarState>(
+      'switchToMessages emits index 2 and updates screen name',
+      build: () => cubit,
+      act: (cubit) => cubit.switchToMessages(),
+      verify: (_) {
+        verify(() => clarityService.setCurrentScreenName('messages')).called(1);
+      },
+      expect: () => [
+        const NavigationBarState(selectedTabIndex: 2),
+      ],
+    );
+
+    blocTest<NavigationBarCubit, NavigationBarState>(
+      'switchToProfile emits index 3 and updates screen name',
+      build: () => cubit,
+      act: (cubit) => cubit.switchToProfile(),
+      verify: (_) {
+        verify(() => clarityService.setCurrentScreenName('profile')).called(1);
+      },
+      expect: () => [
+        const NavigationBarState(selectedTabIndex: 3),
+      ],
+    );
   });
 }

--- a/apps/hotelyn_app/test/features/home/view/home_page_test.dart
+++ b/apps/hotelyn_app/test/features/home/view/home_page_test.dart
@@ -1,0 +1,234 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hotelyn/components/navigation_bar/navigation_bar.dart';
+import 'package:hotelyn/components/navigation_bar/navigation_bar_cubit.dart';
+import 'package:hotelyn/components/text_input/hotelyn_search_input.dart';
+import 'package:hotelyn/core/services/clarity_service.dart';
+import 'package:hotelyn/features/home/home.dart';
+import 'package:hotelyn/features/location/location.dart';
+import 'package:hotelyn/features/messages/messages_cubit.dart';
+import 'package:hotelyn/features/messages/messages_tab.dart';
+import 'package:hotelyn/features/profile/profile_cubit.dart';
+import 'package:hotelyn/features/profile/profile_tab.dart';
+import 'package:hotelyn/features/search/recent_search/cubit/search_cubit.dart';
+import 'package:hotelyn/features/search/recent_search/recent_search_tab.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/helpers.dart';
+
+void main() {
+  group('HomePage', () {
+    late ClarityService clarityService;
+    late LocationCubit locationCubit;
+    late NavigationBarCubit navigationBarCubit;
+
+    setUp(() {
+      clarityService = MockClarityService();
+      locationCubit = MockLocationCubit();
+      navigationBarCubit = NavigationBarCubit(clarityService: clarityService);
+
+      when(() => locationCubit.state).thenReturn(
+        const LocationState(
+          userLocation: UserLocation(
+            latitude: -7.4244,
+            longitude: 109.2304,
+            cityName: 'Purwokerto, Indonesia',
+          ),
+        ),
+      );
+      when(() => locationCubit.stream).thenAnswer(
+        (_) => Stream.value(
+          const LocationState(
+            userLocation: UserLocation(
+              latitude: -7.4244,
+              longitude: 109.2304,
+              cityName: 'Purwokerto, Indonesia',
+            ),
+          ),
+        ),
+      );
+    });
+
+    Widget buildSubject({
+      NavigationBarCubit? navCubit,
+      ProfileCubit? profileCubit,
+      MessagesCubit? messagesCubit,
+      SearchCubit? searchCubit,
+    }) {
+      return RepositoryProvider<ClarityService>.value(
+        value: clarityService,
+        child: BlocProvider<LocationCubit>.value(
+          value: locationCubit,
+          child: HomePage(
+            navigationBarCubit: navCubit ?? navigationBarCubit,
+            profileCubit: profileCubit,
+            messagesCubit: messagesCubit,
+            searchCubit: searchCubit,
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders HomeView, Scaffold, and HotelynNavigationBar', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      expect(find.byType(HomeView), findsOneWidget);
+      expect(find.byType(Scaffold), findsWidgets);
+      expect(find.byType(HotelynNavigationBar), findsOneWidget);
+      expect(find.byType(HomeTab), findsOneWidget);
+    });
+
+    testWidgets('navigation bar displays all 4 top-level destinations', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      expect(find.text('Home'), findsOneWidget);
+      expect(find.text('Search'), findsOneWidget);
+      expect(find.text('Messages'), findsOneWidget);
+      expect(find.text('Profile'), findsOneWidget);
+    });
+
+    testWidgets('tapping Search tab switches to RecentSearchTab', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      await tester.tap(find.text('Search'));
+      await tester.pumpAndSettle();
+
+      expect(navigationBarCubit.state.selectedTabIndex, 1);
+      expect(find.byType(RecentSearchTab), findsOneWidget);
+    });
+
+    testWidgets('tapping Messages tab switches to MessagesTab', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      await tester.tap(find.text('Messages'));
+      await tester.pumpAndSettle();
+
+      expect(navigationBarCubit.state.selectedTabIndex, 2);
+      expect(find.byType(MessagesTab), findsOneWidget);
+    });
+
+    testWidgets('tapping Profile tab switches to ProfileTab', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      await tester.tap(find.text('Profile'));
+      await tester.pumpAndSettle();
+
+      expect(navigationBarCubit.state.selectedTabIndex, 3);
+      expect(find.byType(ProfileTab), findsOneWidget);
+    });
+
+    testWidgets('tapping search quick-entry bar switches to Search tab', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      expect(find.byType(HotelynSearchInput), findsOneWidget);
+      await tester.tap(find.byType(HotelynSearchInput));
+      await tester.pumpAndSettle();
+
+      expect(navigationBarCubit.state.selectedTabIndex, 1);
+    });
+
+    group('back navigation behavior', () {
+      testWidgets(
+        'back button on Search tab switches safely back to Home tab '
+        '(index 0)',
+        (tester) async {
+          await tester.pumpApp(buildSubject());
+
+          // Switch to Search tab
+          await tester.tap(find.text('Search'));
+          await tester.pumpAndSettle();
+          expect(navigationBarCubit.state.selectedTabIndex, 1);
+
+          // Trigger back navigation
+          await tester.binding.handlePopRoute();
+          await tester.pumpAndSettle();
+
+          // Safely back to Home tab
+          expect(navigationBarCubit.state.selectedTabIndex, 0);
+        },
+      );
+
+      testWidgets(
+        'back button on Messages tab switches safely back to Home tab '
+        '(index 0)',
+        (tester) async {
+          await tester.pumpApp(buildSubject());
+
+          // Switch to Messages tab
+          await tester.tap(find.text('Messages'));
+          await tester.pumpAndSettle();
+          expect(navigationBarCubit.state.selectedTabIndex, 2);
+
+          // Trigger back navigation
+          await tester.binding.handlePopRoute();
+          await tester.pumpAndSettle();
+
+          // Safely back to Home tab
+          expect(navigationBarCubit.state.selectedTabIndex, 0);
+        },
+      );
+
+      testWidgets(
+        'back button on Profile tab switches safely back to Home tab '
+        '(index 0)',
+        (tester) async {
+          await tester.pumpApp(buildSubject());
+
+          // Switch to Profile tab
+          await tester.tap(find.text('Profile'));
+          await tester.pumpAndSettle();
+          expect(navigationBarCubit.state.selectedTabIndex, 3);
+
+          // Trigger back navigation
+          await tester.binding.handlePopRoute();
+          await tester.pumpAndSettle();
+
+          // Safely back to Home tab
+          expect(navigationBarCubit.state.selectedTabIndex, 0);
+        },
+      );
+
+      testWidgets(
+        'PopScope allows pop when already on Home tab (index 0)',
+        (tester) async {
+          await tester.pumpApp(buildSubject());
+
+          expect(navigationBarCubit.state.selectedTabIndex, 0);
+
+          final popScope = tester.widget(
+            find.byWidgetPredicate((w) => w is PopScope),
+          ) as PopScope;
+          expect(popScope.canPop, isTrue);
+        },
+      );
+
+      testWidgets(
+        'PopScope denies pop when on non-home tab',
+        (tester) async {
+          await tester.pumpApp(buildSubject());
+
+          await tester.tap(find.text('Search'));
+          await tester.pumpAndSettle();
+
+          final popScope = tester.widget(
+            find.byWidgetPredicate((w) => w is PopScope),
+          ) as PopScope;
+          expect(popScope.canPop, isFalse);
+        },
+      );
+    });
+  });
+}

--- a/apps/hotelyn_app/test/features/home/widgets/home_header_test.dart
+++ b/apps/hotelyn_app/test/features/home/widgets/home_header_test.dart
@@ -1,0 +1,182 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hotelyn/components/navigation_bar/navigation_bar_cubit.dart';
+import 'package:hotelyn/components/navigation_bar/navigation_bar_state.dart';
+import 'package:hotelyn/components/text_input/hotelyn_search_input.dart';
+import 'package:hotelyn/features/home/widgets/home_header.dart';
+import 'package:hotelyn/features/location/location.dart';
+import 'package:mocktail/mocktail.dart';
+
+import '../../../helpers/helpers.dart';
+
+class MockNavCubit extends Mock implements NavigationBarCubit {}
+
+void main() {
+  group('HomeHeader', () {
+    late LocationCubit locationCubit;
+    late NavigationBarCubit navigationBarCubit;
+
+    setUp(() {
+      locationCubit = MockLocationCubit();
+      navigationBarCubit = MockNavCubit();
+      when(() => locationCubit.state).thenReturn(
+        const LocationState(
+          userLocation: UserLocation(
+            latitude: -7.4244,
+            longitude: 109.2304,
+            cityName: 'Purwokerto, Indonesia',
+          ),
+        ),
+      );
+      when(() => navigationBarCubit.state).thenReturn(
+        const NavigationBarState(selectedTabIndex: 0),
+      );
+      when(() => navigationBarCubit.stream).thenAnswer(
+        (_) => Stream.value(const NavigationBarState(selectedTabIndex: 0)),
+      );
+    });
+
+    Widget buildSubject({
+      String userName = 'Katherine',
+      VoidCallback? onNotificationTap,
+      VoidCallback? onSearchTap,
+      VoidCallback? onLocationTap,
+      bool overlapsContent = false,
+    }) {
+      return MultiBlocProvider(
+        providers: [
+          BlocProvider<LocationCubit>.value(value: locationCubit),
+          BlocProvider<NavigationBarCubit>.value(value: navigationBarCubit),
+        ],
+        child: Scaffold(
+          body: SingleChildScrollView(
+            child: HomeHeader(
+              userName: userName,
+              onNotificationTap: onNotificationTap,
+              onSearchTap: onSearchTap,
+              onLocationTap: onLocationTap,
+              overlapsContent: overlapsContent,
+            ),
+          ),
+        ),
+      );
+    }
+
+    testWidgets('renders default user greeting and subtitle', (tester) async {
+      await tester.pumpApp(buildSubject());
+
+      expect(find.text('Hello, Katherine! 👋'), findsOneWidget);
+      expect(find.text("Let's find best hotel"), findsOneWidget);
+    });
+
+    testWidgets('renders custom user greeting when provided', (tester) async {
+      await tester.pumpApp(buildSubject(userName: 'Alex'));
+
+      expect(find.text('Hello, Alex! 👋'), findsOneWidget);
+    });
+
+    testWidgets('renders LocationCard with city name from LocationCubit', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      expect(find.byType(LocationCard), findsOneWidget);
+      expect(find.text('Purwokerto, Indonesia'), findsOneWidget);
+      expect(find.byIcon(Icons.place_outlined), findsOneWidget);
+    });
+
+    testWidgets('tapping LocationCard triggers custom onLocationTap', (
+      tester,
+    ) async {
+      var tapped = false;
+      await tester.pumpApp(
+        buildSubject(onLocationTap: () => tapped = true),
+      );
+
+      await tester.tap(find.byType(LocationCard));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('renders NotificationCard with badge and bell icon', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      expect(find.byType(NotificationCard), findsOneWidget);
+      expect(find.byType(Badge), findsOneWidget);
+      expect(find.byIcon(Icons.notifications), findsOneWidget);
+    });
+
+    testWidgets('tapping NotificationCard triggers custom onNotificationTap', (
+      tester,
+    ) async {
+      var tapped = false;
+      await tester.pumpApp(
+        buildSubject(onNotificationTap: () => tapped = true),
+      );
+
+      await tester.tap(find.byType(NotificationCard));
+      await tester.pumpAndSettle();
+
+      expect(tapped, isTrue);
+    });
+
+    testWidgets('renders HotelynSearchInput when overlapsContent is false', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject());
+
+      expect(find.byType(HotelynSearchInput), findsOneWidget);
+      expect(find.text('Search hotel'), findsOneWidget);
+    });
+
+    testWidgets('hides HotelynSearchInput when overlapsContent is true', (
+      tester,
+    ) async {
+      await tester.pumpApp(buildSubject(overlapsContent: true));
+
+      expect(find.byType(HotelynSearchInput), findsNothing);
+    });
+
+    testWidgets('tapping search input invokes custom onSearchTap', (
+      tester,
+    ) async {
+      var searchTapped = false;
+      await tester.pumpApp(
+        buildSubject(onSearchTap: () => searchTapped = true),
+      );
+
+      await tester.tap(find.byType(HotelynSearchInput));
+      await tester.pumpAndSettle();
+
+      expect(searchTapped, isTrue);
+    });
+
+    testWidgets(
+      'tapping search input switches NavigationBarCubit to search tab '
+      '(index 1) by default',
+      (
+        tester,
+      ) async {
+        when(() => navigationBarCubit.updateSelectedIndex(1)).thenReturn(null);
+
+        await tester.pumpApp(buildSubject());
+
+        await tester.tap(find.byType(HotelynSearchInput));
+        await tester.pumpAndSettle();
+
+        verify(() => navigationBarCubit.updateSelectedIndex(1)).called(1);
+      },
+    );
+
+    test('HotelynHeader delegate properties and rebuild', () {
+      final delegate = HotelynHeader(userName: 'Maria');
+      expect(delegate.maxExtent, 250.0);
+      expect(delegate.minExtent, 240.0);
+      expect(delegate.shouldRebuild(HotelynHeader()), isFalse);
+    });
+  });
+}

--- a/backend/test/data/auth_client_test.dart
+++ b/backend/test/data/auth_client_test.dart
@@ -107,7 +107,8 @@ void main() {
       );
     });
 
-    test('derives a rate-limit code and retry-after from the message', () async {
+    test('derives a rate-limit code and retry-after from the '
+        'message', () async {
       when(() => auth.signInWithOtp(email: any(named: 'email'))).thenThrow(
         const gotrue.AuthException(
           'For security purposes, you can only request this after 27 seconds.',


### PR DESCRIPTION
## Summary & Context
Implements the homepage scaffold and top-level navigation (FE-1301 / Issue #196) in `hotelyn_app`.
The home screen coordinates between the application's primary sections (Home, Search, Messages, and Profile), ensures smooth state retention across tabs using `IndexedStack`, supports safe back-navigation behavior via `PopScope` (popping from non-home tabs navigates back to Home tab index 0 before exiting the app), wires the header greeting, location picker chip with `LocationCubit`, notification shortcut routing to `/notifications`, and provides a search quick-entry bar that seamlessly switches to the search destination.

## Related Issue(s)
- Fixes #196

## Type of Change
- [x] ✨ `feat`: New feature (non-breaking change which adds functionality)
- [ ] 🛠️ `fix`: Bug fix (non-breaking change which fixes an issue)
- [ ] 🧹 `refactor`: Code refactoring without functional changes
- [ ] ⚡ `perf`: Performance optimization
- [ ] 📝 `docs`: Documentation updates
- [ ] 🏗️ `chore`: Tooling, build config, CI, dependencies, or monorepo maintenance
- [ ] 💥 `breaking`: Breaking change (alters existing behavior, APIs, or data models)

## Key Changes

### `apps/hotelyn_app`
- **Homepage Scaffold & Navigation (`home_page.dart`)**:
  - Implemented `HomePage` and extracted `HomeView` supporting injected cubits for robust testability.
  - Configured `IndexedStack` preserving state across all 4 top-level destinations (Home, RecentSearchTab, MessagesTab, ProfileTab).
  - Integrated `PopScope` back-navigation handling ensuring Android back button / pop requests on secondary tabs safely return to the Home tab (index 0) before exiting.
- **Top-Level Navigation Bar (`components/navigation_bar/`)**:
  - Enhanced `HotelynNavigationBar` with design tokens from `california_ui` (`CaliforniaColors.brandPrimary`, `CaliforniaTypography.p12Medium`, `p12Regular`) and `HotelynColors`.
  - Added named tab constants (`homeIndex`, `searchIndex`, `messagesIndex`, `profileIndex`), bounds-checked index switching, and navigation helper methods (`switchToHome`, `switchToSearch`, `switchToMessages`, `switchToProfile`) in `NavigationBarCubit`.
- **Home Header & Search Quick-Entry (`features/home/widgets/`)**:
  - Created `HomeHeader` widget supporting custom user greetings, location picker tapping, notifications tapping, and search quick-entry bar.
  - Kept `HotelynHeader` (`SliverPersistentHeaderDelegate`) fully backwards-compatible while delegating layout to `HomeHeader`.
  - Updated `HotelynSearchInput` with optional `onTap` and `readOnly` support for seamless quick-entry into the search tab.
  - Linked `NotificationCard` to route to `/notifications`.
  - Re-exported widgets from `widgets.dart`.
- **Notifications Route (`features/notifications/`, `app_router.dart`)**:
  - Created placeholder `NotificationsPage` and registered `/notifications` in `AppRouter`.
- **Automated Tests**:
  - Added unit test suite for `NavigationBarCubit` covering initial state, screen name tracking via Clarity, tab transitions, bounds checks, and helper methods.
  - Added comprehensive widget tests for `HomePage` covering destination rendering, tab switching, search quick-entry tap, and back navigation behavior.
  - Added widget tests for `HomeHeader` and `HotelynHeader` covering greeting, location card, notification badge, and search entry.

### `backend`
- Wrapped a test description in `backend/test/data/auth_client_test.dart` to comply with the 80-character line length limit.

## Visual Changes / Screenshots

| Before | After |
| :---: | :---: |
| Basic unconfigured tabs without back navigation handling or interactive search bar entry | Fully wired homepage scaffold with styled California UI navigation bar, greeting header, location chip, notifications route, and safe back navigation |

## Testing & Verification

### Automated Tests
- [x] `melos run analyze` (Static analysis passed with zero errors or warnings with --fatal-infos)
- [x] `melos run test` (100% test suites passed across all packages in the monorepo)
- [x] `melos run format` (Dart formatting verified cleanly across all packages)
- [ ] `supabase test db` (pgTAP database suite passed - required if touching `supabase/`)

### Manual Verification
1. Pumped and verified `HomePage` renders all 4 tabs and switches cleanly on navigation taps.
2. Verified back navigation on Search, Messages, and Profile tabs returns to Home tab index 0 without prematurely popping the route.
3. Verified tapping the search input bar in `HomeHeader` seamlessly activates the Search tab.
4. Verified tapping `NotificationCard` routes to `/notifications`.
5. Verified `LocationCard` displays current user location and opens location priming / manual selection sheets.

## Pre-Submission Checklist
- [x] My branch is rebased on the latest `origin/main`.
- [x] PR title adheres to [Conventional Commits](https://www.conventionalcommits.org/) (e.g., `feat:`, `fix:`, `chore:`).
- [x] Commits follow Conventional Commits standard.
- [x] Code follows repository style guidelines and `analysis_options.yaml`.
- [x] No temporary debug prints, unnecessary logging, or leftover commented code.
- [x] Relevant documentation has been updated (e.g., `README.md`, `CLAUDE.md`, docs).
- [x] I have filled out all applicable sections of this template and removed placeholder comments.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Notifications page with an empty-state message.
  - Notification cards now open the Notifications page.
  - Home greetings can display the signed-in user’s name.
  - Search fields support tapping, typing, enabling/disabling, and submission actions.
  - Added quick navigation from the home header to Search and Notifications.

- **Improvements**
  - Updated bottom navigation styling for clearer selected and unselected states.
  - Back navigation safely returns to the Home tab before exiting.
  - Invalid navigation selections are now safely ignored.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->